### PR TITLE
🎨 Palette: Standardize external links for better UX and accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-25 - Extracted ExternalLink for Presentation Links
+**Learning:** Found that numerous plain `<a>` tags with `target="_blank"` were used in the presentations and projects lists without any screen reader indication that they opened in new tabs or visual cues that they pointed to external domains. Replacing them with the site's existing `<ExternalLink>` component solved this across 13 locations while enforcing the standard site style.
+**Action:** Next time looking for micro-UX opportunities, search specifically for raw `target="_blank"` tags (`grep -r 'target="_blank"'`) and evaluate if they should use `<ExternalLink>` to automatically inherit the `faExternalLinkAlt` icon and accessible props.

--- a/src/pages/presentations.tsx
+++ b/src/pages/presentations.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import Layout from "../components/layout"
+import ExternalLink from "../components/externalLink"
 import SEO from "../components/seo"
 
 export const Head: React.FC = () => (
@@ -23,13 +24,12 @@ const PresentationsPage: React.FC = () => (
           2019
           <ul>
             <li>
-              <a
+              <ExternalLink
                 href="https://drive.google.com/open?id=1UtHVimNzWgHmKRO9C2p_tGpXTb1IZIvhbr6KdOPHSPE"
-                target="_blank"
-                rel="noopener noreferrer"
+                ariaLabel="JHipster presentation (opens in a new tab)"
               >
                 JHipster
-              </a>
+              </ExternalLink>
             </li>
           </ul>
         </li>
@@ -37,22 +37,20 @@ const PresentationsPage: React.FC = () => (
           2018
           <ul>
             <li>
-              <a
+              <ExternalLink
                 href="https://drive.google.com/open?id=1F858H6PNqXatZ0TgAZJi0u7udhE77jYj_SGOb1ZbrNQ"
-                target="_blank"
-                rel="noopener noreferrer"
+                ariaLabel="Hystrix presentation (opens in a new tab)"
               >
                 Hystrix
-              </a>
+              </ExternalLink>
             </li>
             <li>
-              <a
+              <ExternalLink
                 href="https://drive.google.com/open?id=1z_0CFzrrYdD4OGiWn_ue3ev2Tb7Hmklnk76mp7mC-Zo"
-                target="_blank"
-                rel="noopener noreferrer"
+                ariaLabel="Spring Cloud presentation (opens in a new tab)"
               >
                 Spring Cloud
-              </a>
+              </ExternalLink>
             </li>
           </ul>
         </li>
@@ -60,20 +58,18 @@ const PresentationsPage: React.FC = () => (
           2017
           <ul>
             <li>
-              <a
+              <ExternalLink
                 href="https://drive.google.com/open?id=16jnaqvufQd43odXG8TmrdweUpRGJxjBwpEywuZI9KOU"
-                target="_blank"
-                rel="noopener noreferrer"
+                ariaLabel="ANTLR4 - NEJUG Edition presentation (opens in a new tab)"
               >
                 ANTLR4 - NEJUG Edition
-              </a>{" "}
-              <a
+              </ExternalLink>{" "}
+              <ExternalLink
                 href="https://vimeo.com/199478127"
-                target="_blank"
-                rel="noopener noreferrer"
+                ariaLabel="Video Recording (opens in a new tab)"
               >
                 (Video Recording)
-              </a>
+              </ExternalLink>
             </li>
           </ul>
         </li>
@@ -81,67 +77,60 @@ const PresentationsPage: React.FC = () => (
           2016
           <ul>
             <li>
-              <a
+              <ExternalLink
                 href="https://drive.google.com/open?id=1jif18rAMUMmpZa5JuWM4BOxgNdV9g2H5jU3CZHOzWXM"
-                target="_blank"
-                rel="noopener noreferrer"
+                ariaLabel="ANTLR4 presentation (opens in a new tab)"
               >
                 ANTLR4
-              </a>
+              </ExternalLink>
             </li>
             <li>
-              <a
+              <ExternalLink
                 href="https://drive.google.com/open?id=1nqVxyn2qz9HJB9PyvFbJNJ0BvplgB5skptgC7niGz40"
-                target="_blank"
-                rel="noopener noreferrer"
+                ariaLabel="Java Classloader presentation (opens in a new tab)"
               >
                 Java Classloader
-              </a>
+              </ExternalLink>
             </li>
             <li>
-              <a
+              <ExternalLink
                 href="https://drive.google.com/open?id=1_sZ-URrqY7B90I_ImvmIsLDA0t4k-NuJfSqHsJS4724"
-                target="_blank"
-                rel="noopener noreferrer"
+                ariaLabel="Java Persistance API Overview presentation (opens in a new tab)"
               >
                 Java Persistance API Overview
-              </a>
+              </ExternalLink>
             </li>
             <li>
-              <a
+              <ExternalLink
                 href="https://drive.google.com/open?id=1fWIGVNfDkyNYgz1ExBUulds_OnUCaMk2dshzPD972gM"
-                target="_blank"
-                rel="noopener noreferrer"
+                ariaLabel="Git Overview presentation (opens in a new tab)"
               >
                 Git Overview
-              </a>
+              </ExternalLink>
             </li>
             <li>
-              <a
+              <ExternalLink
                 href="https://drive.google.com/open?id=10-LJWRSkSUh3GzioqF2MEUQHjm4zKx4yYDlX5rhMI-Q"
-                target="_blank"
-                rel="noopener noreferrer"
+                ariaLabel="Grails 2.1 Unit Testing presentation (opens in a new tab)"
               >
                 Grails 2.1 Unit Testing
-              </a>
+              </ExternalLink>
             </li>
             <li>
-              <a
+              <ExternalLink
                 href="https://drive.google.com/open?id=13hhP4uQXJu2HktC_PX_TXwmzy2WsjRoYNdix4UYdp70"
-                target="_blank"
-                rel="noopener noreferrer"
+                ariaLabel="Grails 2.5 Unit Testing presentation (opens in a new tab)"
               >
                 Grails 2.5 Unit Testing
-              </a>
+              </ExternalLink>
             </li>
             <li>
-              <a
+              <ExternalLink
                 href="https://drive.google.com/open?id=1d4KLTHiFEZlRN0YmDUs7aT2bHVATpxGKQb0OOgk2jrA"
-                target="_blank"
-                rel="noopener noreferrer"
+                ariaLabel="Spring Boot Intro presentation (opens in a new tab)"
               >
                 Spring Boot Intro
-              </a>
+              </ExternalLink>
             </li>
           </ul>
         </li>

--- a/src/pages/projects.tsx
+++ b/src/pages/projects.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import Layout from "../components/layout"
 import ProjectEntry from "../components/projects/projectEntry"
+import ExternalLink from "../components/externalLink"
 import SEO from "../components/seo"
 
 export const Head: React.FC = () => (
@@ -41,13 +42,12 @@ const ProjectsPage: React.FC = () => (
           8 interface features and reflection to automatic test Getters and
           Setters, hashCode(), equals(), etc. I would recommend using a tool
           such as{" "}
-          <a
+          <ExternalLink
             href="https://projectlombok.org/"
-            target="_blank"
-            rel="noopener noreferrer"
+            ariaLabel="Lombok project website (opens in a new tab)"
           >
             Lombok
-          </a>{" "}
+          </ExternalLink>{" "}
           to generate &rdquo;data&ldquo; methods instead.
         </ProjectEntry>
         <ProjectEntry


### PR DESCRIPTION
**💡 What:** Replaced 13 instances of plain `<a>` tags utilizing `target="_blank"` with the site's standardized `<ExternalLink>` component in `presentations.tsx` and `projects.tsx`.

**🎯 Why:** Users were navigating to Google Drive, Vimeo, and external project sites from the Presentations and Projects pages without any visual or screen-reader cues that the links would open in a new tab or navigate away from the site. Using the `<ExternalLink>` component automatically appends the `faExternalLinkAlt` icon, standardizing the UI, and enables adding accessible `ariaLabel`s.

**📸 Before/After:**
*(See attached screenshots and video in the verification phase for visual proof of the added external link icons).*

**♿ Accessibility:**
Added descriptive `ariaLabel` attributes to every updated link (e.g., `"JHipster presentation (opens in a new tab)"`). This ensures screen reader users are aware of the link's context and the behavioral change (opening a new tab) before they activate it.

---
*PR created automatically by Jules for task [1292174948111584435](https://jules.google.com/task/1292174948111584435) started by @robertsmieja*