### PR TITLE
Refactor resume styling and layout for improved print support

### DIFF
--- a/src/components/resume/devops.tsx
+++ b/src/components/resume/devops.tsx
@@ -5,24 +5,30 @@ import { css, jsx } from "@emotion/react"
 import React from "react"
 
 const listStyles = css`
-  @media print {
-    display: inline;
-    padding: 0;
-    margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.15rem 1.25rem;
+  padding-left: 0;
+  list-style: none;
+  margin: 0.25rem 0 0.5rem 0;
 
-    & > li {
+  @media print {
+    display: block;
+    padding-left: 0;
+    margin: 0;
+    list-style: none;
+
+    li {
       display: inline;
-      padding: 0;
       margin: 0;
-      white-space: nowrap;
     }
 
-    & > li:not(:last-child)::after {
-      content: "•";
+    li:not(:last-child)::after {
       display: inline;
       clear: none;
+      content: " \\2022 ";
       margin: 0 0.5ch;
-      color: var(--theme-ui-colors-textMuted);
+      color: #666;
     }
   }
 `

--- a/src/components/resume/experience/experienceEntry.tsx
+++ b/src/components/resume/experience/experienceEntry.tsx
@@ -57,7 +57,7 @@ const ExperienceEntry: React.FC<ExperienceEntryProperties> = ({
   jobTitle,
   location,
 }: ExperienceEntryProperties) => (
-  <div id={`experience-${company.replace(" ", "_")}`} css={entryStyles}>
+  <div id={`experience-${company.replace(/\s+/g, "_")}`} css={entryStyles}>
     <div css={headerStyles}>
       <p>
         {company}, {location}

--- a/src/components/resume/profile.tsx
+++ b/src/components/resume/profile.tsx
@@ -7,10 +7,10 @@ const Profile: React.FC = () => (
     <h2>
       <FontAwesomeIcon icon={faUser} aria-hidden="true" /> Profile
     </h2>
-    <dl>
+    <p>
       Innovative problem solver. Life long learner, who is constantly on the
       lookout for new technology, to find new solutions to problems.
-    </dl>
+    </p>
   </div>
 )
 

--- a/src/components/resume/technology/clouds.tsx
+++ b/src/components/resume/technology/clouds.tsx
@@ -4,10 +4,13 @@ import React from "react"
 
 // Extract inline Emotion CSS to prevent re-serialization on every render
 const listStyles = css`
-  li {
-    margin-left: 2rem;
-    float: left;
-  }
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.15rem 1.25rem;
+  padding-left: 0;
+  list-style: none;
+  margin: 0.25rem 0 0.5rem 0;
+
   @media print {
     display: block;
     padding-left: 0;
@@ -17,7 +20,6 @@ const listStyles = css`
     li {
       display: inline;
       margin: 0;
-      float: none;
     }
 
     li:not(:last-child)::after {

--- a/src/components/resume/technology/databases.tsx
+++ b/src/components/resume/technology/databases.tsx
@@ -3,24 +3,30 @@ import { css, jsx } from "@emotion/react"
 import React from "react"
 
 const listStyles = css`
-  @media print {
-    display: inline;
-    padding: 0;
-    margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.15rem 1.25rem;
+  padding-left: 0;
+  list-style: none;
+  margin: 0.25rem 0 0.5rem 0;
 
-    & > li {
+  @media print {
+    display: block;
+    padding-left: 0;
+    margin: 0;
+    list-style: none;
+
+    li {
       display: inline;
-      padding: 0;
       margin: 0;
-      white-space: nowrap;
     }
 
-    & > li:not(:last-child)::after {
-      content: "•";
+    li:not(:last-child)::after {
       display: inline;
       clear: none;
+      content: " \\2022 ";
       margin: 0 0.5ch;
-      color: var(--theme-ui-colors-textMuted);
+      color: #666;
     }
   }
 `

--- a/src/components/resume/technology/frameworks.tsx
+++ b/src/components/resume/technology/frameworks.tsx
@@ -3,24 +3,30 @@ import { css, jsx } from "@emotion/react"
 import React from "react"
 
 const listStyles = css`
-  @media print {
-    display: inline;
-    padding: 0;
-    margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.15rem 1.25rem;
+  padding-left: 0;
+  list-style: none;
+  margin: 0.25rem 0 0.5rem 0;
 
-    & > li {
+  @media print {
+    display: block;
+    padding-left: 0;
+    margin: 0;
+    list-style: none;
+
+    li {
       display: inline;
-      padding: 0;
       margin: 0;
-      white-space: nowrap;
     }
 
-    & > li:not(:last-child)::after {
-      content: "•";
+    li:not(:last-child)::after {
       display: inline;
       clear: none;
+      content: " \\2022 ";
       margin: 0 0.5ch;
-      color: var(--theme-ui-colors-textMuted);
+      color: #666;
     }
   }
 `

--- a/src/components/resume/technology/operatingSystems.tsx
+++ b/src/components/resume/technology/operatingSystems.tsx
@@ -10,24 +10,30 @@ import { css, jsx } from "@emotion/react"
 import React from "react"
 
 const listStyles = css`
-  @media print {
-    display: inline;
-    padding: 0;
-    margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.15rem 1.25rem;
+  padding-left: 0;
+  list-style: none;
+  margin: 0.25rem 0 0.5rem 0;
 
-    & > li {
+  @media print {
+    display: block;
+    padding-left: 0;
+    margin: 0;
+    list-style: none;
+
+    li {
       display: inline;
-      padding: 0;
       margin: 0;
-      white-space: nowrap;
     }
 
-    & > li:not(:last-child)::after {
-      content: "•";
+    li:not(:last-child)::after {
       display: inline;
       clear: none;
+      content: " \\2022 ";
       margin: 0 0.5ch;
-      color: var(--theme-ui-colors-textMuted);
+      color: #666;
     }
   }
 `

--- a/src/components/resume/technology/programmingLanguages.tsx
+++ b/src/components/resume/technology/programmingLanguages.tsx
@@ -4,10 +4,13 @@ import React from "react"
 
 // Extract inline Emotion CSS to prevent re-serialization on every render
 const listStyles = css`
-  li {
-    margin-left: 2rem;
-    float: left;
-  }
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.15rem 1.25rem;
+  padding-left: 0;
+  list-style: none;
+  margin: 0.25rem 0 0.5rem 0;
+
   @media print {
     display: block;
     padding-left: 0;
@@ -17,7 +20,6 @@ const listStyles = css`
     li {
       display: inline;
       margin: 0;
-      float: none;
     }
 
     li:not(:last-child)::after {

--- a/src/pages/resume.tsx
+++ b/src/pages/resume.tsx
@@ -38,12 +38,42 @@ export const Head: React.FC = () => (
 )
 
 // Extract inline Emotion CSS to prevent re-serialization on every render
+const resumeContainerStyles = css`
+  max-width: 8.5in;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+
+  @media print {
+    max-width: 100%;
+    padding: 0;
+    margin: 0;
+  }
+`
+
 const headerContainerStyles = css`
   text-align: center;
   position: relative;
+  padding-bottom: 0.75rem;
+  border-bottom: 2px solid #222;
+  margin-bottom: 0.25rem;
+
+  h1 {
+    margin: 0.5rem 0 0.25rem;
+    font-size: 2.25rem;
+    letter-spacing: 0.02em;
+  }
+
+  h4 {
+    margin: 0 0 0.25rem;
+    font-weight: 400;
+    color: #444;
+    font-size: 1.1rem;
+  }
 
   @media print {
-    margin-bottom: 0.5rem;
+    border-bottom: 1.5px solid #222;
+    margin-bottom: 0.3rem;
+    padding-bottom: 0.3rem;
     h1 {
       margin: 0.2rem 0;
       font-size: 1.8rem;
@@ -77,30 +107,49 @@ const printButtonStyles = css`
 `
 
 const gridContainerStyles = css`
-  display: grid;
-  align-content: start;
-  flex-direction: column;
-
-  @media (min-width: 800px) {
-    flex-wrap: wrap;
-  }
-
-  height: 100%;
-  width: 100%;
-
   text-align: left;
 
-  @media print {
-    display: block; /* Remove grid to allow better page breaking */
+  h2 {
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    border-bottom: 1.5px solid #444;
+    padding-bottom: 0.2rem;
+    margin-top: 1.25rem;
+    margin-bottom: 0.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
 
-    /* Make h2s smaller and tighter for print */
-    h2 {
-      margin: 0.2rem 0 0.1rem 0;
-      font-size: 1.2rem;
-      border-bottom: 1px solid #ccc;
+  dl {
+    margin: 0 0 0.5rem 0;
+
+    dt {
+      font-weight: 600;
+      font-size: 0.85rem;
+      color: #555;
+      margin-bottom: 0.1rem;
     }
 
-    /* Tighter spacing for definitions/lists */
+    dd {
+      margin-left: 0;
+      margin-bottom: 0.4rem;
+    }
+  }
+
+  @media print {
+    display: block;
+
+    h2 {
+      margin: 0.3rem 0 0.15rem 0;
+      font-size: 0.9rem;
+      border-bottom: 1px solid #ccc;
+      padding-bottom: 0.1rem;
+      letter-spacing: 0.05em;
+    }
+
     dl,
     ul {
       margin-top: 0;
@@ -115,29 +164,31 @@ const gridContainerStyles = css`
 
 const ResumePage: React.FC = () => (
   <Layout>
-    <div css={headerContainerStyles}>
-      <h1>Robert Smieja</h1>
-      <h4>Polyglot Full-stack Software Engineer</h4>
-      <button
-        type="button"
-        css={printButtonStyles}
-        onClick={() => {
-          if (typeof window !== "undefined") {
-            window.print()
-          }
-        }}
-        aria-label="Print Resume"
-        title="Print Resume"
-      >
-        <FontAwesomeIcon icon={faPrint} aria-hidden="true" />
-      </button>
-    </div>
-    <div css={gridContainerStyles}>
-      <Technology />
-      <DevOps />
-      <Experience />
-      <Profile />
-      <Education />
+    <div css={resumeContainerStyles}>
+      <div css={headerContainerStyles}>
+        <h1>Robert Smieja</h1>
+        <h4>Polyglot Full-stack Software Engineer</h4>
+        <button
+          type="button"
+          css={printButtonStyles}
+          onClick={() => {
+            if (typeof window !== "undefined") {
+              window.print()
+            }
+          }}
+          aria-label="Print Resume"
+          title="Print Resume"
+        >
+          <FontAwesomeIcon icon={faPrint} aria-hidden="true" />
+        </button>
+      </div>
+      <div css={gridContainerStyles}>
+        <Experience />
+        <Profile />
+        <Technology />
+        <DevOps />
+        <Education />
+      </div>
     </div>
   </Layout>
 )


### PR DESCRIPTION
## Summary
This PR refactors the resume page styling to improve both screen and print layouts. The changes include extracting shared CSS patterns, improving the visual hierarchy, and standardizing list styling across resume components.

## Key Changes

- **Added resume container wrapper** with max-width constraint and responsive padding that collapses for print
- **Enhanced header styling** with improved typography (h1/h4 sizing and spacing) and a bottom border separator
- **Refactored grid container** from flex-based layout to semantic block layout with improved h2 and dl styling for both screen and print
- **Standardized list styling** across all technology and DevOps components using flexbox with consistent gap spacing, replacing inconsistent float-based and inline approaches
- **Improved print styles** with tighter spacing, adjusted font sizes, and better page-break behavior
- **Changed Profile section** from definition list (`<dl>`) to paragraph (`<p>`) for semantic correctness
- **Fixed regex pattern** in experience entry ID generation to handle multiple spaces (`/\s+/g` instead of single space replacement)
- **Reordered resume sections** to prioritize Experience and Profile before Technology and DevOps

## Notable Implementation Details

- Extracted inline Emotion CSS styles to prevent re-serialization on every render
- Unified list styling pattern across 6 different technology/skill components with flexbox layout for screen and inline display for print
- Print media queries now use consistent spacing values (0.3rem, 0.9rem, etc.) for better page layout control
- Removed theme-ui color variable dependency in favor of explicit hex colors (#666, #444, etc.) for better maintainability

https://claude.ai/code/session_01SU3HweP8qDJfAVLte52VPG