### PR TITLE
Fix FontAwesome large icon on initial load

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,4 @@
+import { config } from "@fortawesome/fontawesome-svg-core"
+import "@fortawesome/fontawesome-svg-core/styles.css"
+
+config.autoAddCss = false

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,4 @@
+import { config } from "@fortawesome/fontawesome-svg-core"
+import "@fortawesome/fontawesome-svg-core/styles.css"
+
+config.autoAddCss = false

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,16 +1,10 @@
 /** @jsx jsx */
 import * as normalize from "@csstools/normalize.css"
 import { css, Global, jsx } from "@emotion/react"
-import { config } from "@fortawesome/fontawesome-svg-core"
-// fix for font-awesome large icon on initial load - https://github.com/FortAwesome/react-fontawesome#nextjs
-import "@fortawesome/fontawesome-svg-core/styles.css" // Import the CSS
 import React from "react"
 import useSiteMetadata from "../lib/hooks/useSiteMetadata"
 import Footer from "./footer"
 import Header from "./header"
-
-// Import the CSS
-config.autoAddCss = false // Tell Font Awesome to skip adding the CSS automatically since it's being imported above
 
 const globalCss = css`
   ${normalize}


### PR DESCRIPTION
Moved FontAwesome CSS configuration to Gatsby's entry points (`gatsby-browser.js` and `gatsby-ssr.js`) to ensure styles are available during initial load and SSR, preventing the large icon flash (FOUI). Removed redundant configuration from `src/components/layout.tsx`.

---
*PR created automatically by Jules for task [11735431571452683760](https://jules.google.com/task/11735431571452683760) started by @robertsmieja*