### PR TITLE
Add lodash security override to pnpm configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
   },
   "pnpm": {
     "overrides": {
+      "lodash": ">=4.18.0",
       "path-to-regexp": ">=0.1.13",
       "serialize-javascript": ">=7.0.5",
       "brace-expansion@<1.1.13": "1.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  lodash: '>=4.18.0'
   path-to-regexp: '>=0.1.13'
   serialize-javascript: '>=7.0.5'
   brace-expansion@<1.1.13: 1.1.13
@@ -4477,9 +4478,6 @@ packages:
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
-
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
@@ -7872,7 +7870,7 @@ snapshots:
       common-tags: 1.8.2
       graphql: 16.13.2
       import-from: 4.0.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       tslib: 2.4.1
 
   '@graphql-codegen/plugin-helpers@3.1.2(graphql@16.13.2)':
@@ -7882,7 +7880,7 @@ snapshots:
       common-tags: 1.8.2
       graphql: 16.13.2
       import-from: 4.0.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       tslib: 2.4.1
 
   '@graphql-codegen/schema-ast@2.6.1(graphql@16.13.2)':
@@ -12503,8 +12501,6 @@ snapshots:
   lodash.truncate@4.4.2: {}
 
   lodash.uniq@4.5.0: {}
-
-  lodash@4.17.23: {}
 
   lodash@4.18.1: {}
 


### PR DESCRIPTION
## Summary
Added a pnpm override to enforce a minimum version constraint for the `lodash` dependency across the project.

## Changes
- Added `"lodash": ">=4.18.0"` to the pnpm overrides configuration in `package.json`

## Details
This override ensures that lodash is resolved to version 4.18.0 or higher throughout the dependency tree, helping to mitigate potential security vulnerabilities in older versions of the package. This is a common practice for managing transitive dependencies and maintaining security standards across the project.

https://claude.ai/code/session_013smsNusgXAw2bcNEgfvWqt