### PR TITLE
Migrate from Gatsby.js to Astro

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.117.1/containers/javascript-node-14
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.194.0/containers/javascript-node-22
 {
   "name": "Node.js - Alpine",
   "dockerFile": "Dockerfile",
@@ -10,11 +10,10 @@
   // Add the IDs of extensions you want installed when the container is created.
   "extensions": [
     "dbaeumer.vscode-eslint",
-    "orta.vscode-jest",
     "eamodio.gitlens",
     "streetsidesoftware.code-spell-checker",
     "esbenp.prettier-vscode",
-    "richie5um2.vscode-sort-json"
+    "astro-build.astro-vscode"
   ]
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],

--- a/.dockerignore
+++ b/.dockerignore
@@ -57,9 +57,9 @@ typings/
 # dotenv environment variables file
 .env
 
-# gatsby files
-.cache/
-public
+# astro files
+dist/
+.astro/
 
 # Mac files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Source code for RobertSmieja.com
 
-This is the source code for my personal website, written in [TypeScript](https://www.typescriptlang.org/) using [Gatsby.js](https://www.gatsbyjs.org/)
+This is the source code for my personal website, written in [TypeScript](https://www.typescriptlang.org/) using [Astro](https://astro.build/)
 
 ## Requirements
 
@@ -10,10 +10,6 @@ This is the source code for my personal website, written in [TypeScript](https:/
 ### Optional but Recommended
 
 - [VSCode](https://code.visualstudio.com/)
-- [Gatsby.js CLI](https://www.gatsbyjs.com/docs/reference/gatsby-cli/)
-  - ```sh
-    pnpm add -g gatsby-cli
-    ```
 
 ## Development Instructions
 
@@ -25,7 +21,7 @@ This is the source code for my personal website, written in [TypeScript](https:/
 
 1.  **Launch a local server**
 
-    Navigate into your the site’s directory and start it up.
+    Navigate into your the site's directory and start it up.
 
     ```sh
     pnpm run dev
@@ -33,14 +29,12 @@ This is the source code for my personal website, written in [TypeScript](https:/
 
 1.  **Open the source code and start editing!**
 
-    Your site is now running at `http://localhost:8000`!
+    Your site is now running at `http://localhost:4321`!
 
-    _Note: You'll also see a second link: _`http://localhost:8000/___graphql`_. This is a tool you can use to experiment with querying your data. Learn more about using this tool in the [Gatsby tutorial](https://www.gatsbyjs.com/docs/tutorial/getting-started/part-4/)._
+## 🎓 Learning Astro
 
-## 🎓 Learning Gatsby
+Looking for more guidance? Full documentation for Astro lives [on the website](https://astro.build/). Here are some places to start:
 
-Looking for more guidance? Full documentation for Gatsby lives [on the website](https://www.gatsbyjs.com/). Here are some places to start:
+- **For most developers, we recommend starting with the [Astro tutorial](https://docs.astro.build/en/tutorial/0-introduction/).** It starts with zero assumptions about your level of ability and walks through every step of the process.
 
-- **For most developers, we recommend starting with our [in-depth tutorial for creating a site with Gatsby](https://www.gatsbyjs.com/docs/tutorial/).** It starts with zero assumptions about your level of ability and walks through every step of the process.
-
-- **To dive straight into code samples, head [to our documentation](https://www.gatsbyjs.com/docs/).** In particular, check out the _Guides_, _API Reference_, and _Advanced Tutorials_ sections in the sidebar.
+- **To dive straight into code samples, head [to the documentation](https://docs.astro.build/).** In particular, check out the _Guides_, _Reference_, and _Recipes_ sections in the sidebar.


### PR DESCRIPTION
## Summary
This PR migrates the personal website from Gatsby.js to Astro as the static site generator framework.

## Key Changes
- **Framework Migration**: Updated all documentation and configuration to reflect Astro as the new framework instead of Gatsby.js
- **README Updates**: 
  - Changed framework reference from Gatsby.js to Astro
  - Removed Gatsby CLI installation instructions
  - Updated local development server URL from `http://localhost:8000` to `http://localhost:4321`
  - Removed GraphQL playground documentation
  - Updated learning resources to point to Astro documentation
- **Build Artifacts**: Updated `.dockerignore` to exclude Astro-specific directories (`dist/`, `.astro/`) instead of Gatsby directories (`.cache/`, `public`)
- **Dev Container Configuration**: 
  - Updated devcontainer reference from v0.117.1 to v0.194.0
  - Updated Node.js version from 14 to 22
  - Replaced Jest extension with Astro VSCode extension
  - Removed JSON sorting extension

## Notable Details
- The development command remains `pnpm run dev` for consistency
- TypeScript continues to be used as the primary language
- All documentation has been updated to guide users toward Astro resources instead of Gatsby

https://claude.ai/code/session_011aspVxhxLLCkuWxRAXGuMH