### PR TITLE
🎨 Palette: Add `aria-current="page"` to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-04-13 - Added aria-current to Astro navigation links
+**Learning:** Astro doesn't automatically manage aria-current="page" based on active routing state like some frameworks (e.g. Gatsby's <Link> component does). When manually tracking active routes with class:list, accessibility requires explicitly setting aria-current alongside the visual active class.
+**Action:** Always manually sync aria-current="page" with the visual .active state in custom Astro navigation components.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,17 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +38,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +47,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
💡 **What**: Added the `aria-current="page"` attribute to the main navigation links in `src/components/Header.astro`. The attribute dynamically toggles based on the current page's path.

🎯 **Why**: While the active link state was visually communicated via the `.active` CSS class, this information was completely hidden from screen readers. This micro-UX improvement ensures that visually impaired users utilizing assistive technologies are clearly informed about which navigation item corresponds to the current page they are viewing.

♿ **Accessibility**: 
- Added `aria-current="page"` to accurately broadcast the active state of navigation links.
- Uses `undefined` when not active to ensure Astro correctly omits the attribute rather than rendering `aria-current="false"`, keeping the DOM clean and semantic.

---
*PR created automatically by Jules for task [3361464585963900386](https://jules.google.com/task/3361464585963900386) started by @robertsmieja*