### PR TITLE
🎨 Palette: Add `aria-current` to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,3 @@
-## 2024-04-09 - Added actionable link to empty 404 state
-**Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
-**Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+## 2024-04-15 - [Astro Navigation Links Active State Accessibility]
+**Learning:** In Astro, navigation links tracking active routes using custom classes (e.g., `class:list={[{ active: ... }]}`) do not automatically manage accessibility state. They lack `aria-current="page"`.
+**Action:** When creating navigation menus in Astro that highlight the active page visually via CSS classes, explicitly bind `aria-current={isActive ? "page" : undefined}` to inform screen readers of the active navigation item. Passing `undefined` correctly omits the attribute when false.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,19 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}
+        >
+          Home
+        </a>
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +40,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +49,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
💡 **What:** Added dynamic `aria-current="page"` attributes to all navigation links in the header.
🎯 **Why:** To ensure screen readers announce which page is currently active, matching the visual indication provided by the `.active` CSS class.
♿ **Accessibility:** Fixes a minor missing state for screen readers making site navigation significantly better.

---
*PR created automatically by Jules for task [1137712484522507956](https://jules.google.com/task/1137712484522507956) started by @robertsmieja*