### PR TITLE
Fix blog rendering: table styles, footnote styles, scoped clearfix

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -117,6 +117,32 @@ const formattedUpdated =
     color: #555;
   }
 
+  .article :global(table) {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 1.5rem 0;
+  }
+
+  .article :global(th),
+  .article :global(td) {
+    border: 1px solid #ddd;
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+  }
+
+  .article :global(th) {
+    background: #f5f5f5;
+    font-weight: 600;
+  }
+
+  .article :global(.footnotes) {
+    border-top: 1px solid #eee;
+    margin-top: 3rem;
+    padding-top: 1rem;
+    font-size: 0.875rem;
+    color: #555;
+  }
+
   .date {
     color: #666;
     font-size: 0.9rem;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -45,7 +45,7 @@
 
 /* clearfix */
 /* https://developer.mozilla.org/en-US/docs/Web/CSS/clear */
-*::after {
+.clearfix::after {
   content: "";
   display: block;
   clear: both;


### PR DESCRIPTION
## Summary

- **Tables were unstyled** — the comparison table in the SPAR Patterns post rendered with no borders or padding (just raw text columns). Added `border-collapse`, cell borders, padding, and a light header background to `[...slug].astro`.
- **Footnote section was unstyled** — added a top border and muted font to visually separate the footnotes from the post body.
- **`*::after` clearfix was too broad** — `global.css` applied `display: block; clear: both` to the `::after` of every element, including `<sup>` (footnote reference superscripts) and `<td>`/`<th>` (table cells). Changed to `.clearfix::after` so it only applies when explicitly needed. `Header.astro` already has its own scoped `header::after` clearfix for its floated `<li>` elements, so nothing breaks.

## Test plan

- [ ] Visit the SPAR Patterns post and confirm the comparison table has visible borders and readable column headers
- [ ] Visit both 04-19 posts and confirm footnote references appear as superscripts and the footnotes section is visually separated at the bottom
- [ ] Confirm the site header still renders correctly (nav links still float/wrap as before)

https://claude.ai/code/session_01LnbLbV6sRVgGmp9XpWDsoG