### PR TITLE
Remove "Anthropic Five" branding from blog post

### DIFF
--- a/src/content/blog/2026-04-19-coding-with-ai-the-spar-patterns/index.md
+++ b/src/content/blog/2026-04-19-coding-with-ai-the-spar-patterns/index.md
@@ -110,7 +110,7 @@ The underlying principle is the same in both cases: **two perspectives on the sa
 
 ---
 
-> **Note:** SPAR is a tactical workflow for human-AI pair programming. If you want to see how these session-level habits translate into the design of fully autonomous systems, read the companion post: [Designing with AI: The Anthropic Five](/blog/2026-04-19-designing-with-ai-the-anthropic-five/).
+> **Note:** SPAR is a tactical workflow for human-AI pair programming. If you want to see how these session-level habits translate into the design of fully autonomous systems, read the companion post: [Designing with AI: Five Agentic Patterns](/blog/2026-04-19-designing-with-ai-five-agentic-patterns/).
 
 [^1]: Ayende Rahien, [Agents, Code Reviews, and the Bottleneck Shift, Oh My](https://ayende.com/blog/203939-C/agents-code-reviews-and-the-bottleneck-shift-oh-my)
 [^2]: Wikipedia, [Pair programming](https://en.wikipedia.org/wiki/Pair_programming)

--- a/src/content/blog/2026-04-19-coding-with-ai-the-spar-patterns/index.md
+++ b/src/content/blog/2026-04-19-coding-with-ai-the-spar-patterns/index.md
@@ -110,7 +110,7 @@ The underlying principle is the same in both cases: **two perspectives on the sa
 
 ---
 
-> **Note:** SPAR is a tactical workflow for human-AI pair programming. If you want to see how these session-level habits translate into the design of fully autonomous systems, read the companion post: [Designing with AI: Five Agentic Patterns](/blog/2026-04-19-designing-with-ai-five-agentic-patterns/).
+> **Note:** SPAR is a tactical workflow for human-AI pair programming. If you want to see how these session-level habits translate into the design of fully autonomous systems, read the companion post: [Designing with AI: Agentic Design Patterns](/blog/2026-04-19-designing-with-ai-agentic-design-patterns/).
 
 [^1]: Ayende Rahien, [Agents, Code Reviews, and the Bottleneck Shift, Oh My](https://ayende.com/blog/203939-C/agents-code-reviews-and-the-bottleneck-shift-oh-my)
 [^2]: Wikipedia, [Pair programming](https://en.wikipedia.org/wiki/Pair_programming)

--- a/src/content/blog/2026-04-19-designing-with-ai-agentic-design-patterns/index.md
+++ b/src/content/blog/2026-04-19-designing-with-ai-agentic-design-patterns/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Designing with AI: Five Agentic Patterns"
+title: "Designing with AI: Agentic Design Patterns"
 date: "2026-04-19"
 description: "Five design patterns from Anthropic's Building Effective Agents: Prompt Chaining, Routing, Parallelization, Orchestrator-Workers, and Evaluator-Optimizer."
 tags: ["ai", "agents", "design-patterns", "architecture", "anthropic"]

--- a/src/content/blog/2026-04-19-designing-with-ai-five-agentic-patterns/index.md
+++ b/src/content/blog/2026-04-19-designing-with-ai-five-agentic-patterns/index.md
@@ -1,7 +1,7 @@
 ---
-title: "Designing with AI: The Anthropic Five"
+title: "Designing with AI: Five Agentic Patterns"
 date: "2026-04-19"
-description: "The five design patterns from Anthropic's Building Effective Agents: Prompt Chaining, Routing, Parallelization, Orchestrator-Workers, and Evaluator-Optimizer."
+description: "Five design patterns from Anthropic's Building Effective Agents: Prompt Chaining, Routing, Parallelization, Orchestrator-Workers, and Evaluator-Optimizer."
 tags: ["ai", "agents", "design-patterns", "architecture", "anthropic"]
 ---
 


### PR DESCRIPTION
## Summary

- Renames the blog post from "Designing with AI: The Anthropic Five" to "Designing with AI: Five Agentic Patterns"
- Renames the directory from `2026-04-19-designing-with-ai-the-anthropic-five` to `2026-04-19-designing-with-ai-five-agentic-patterns` (updates the URL slug)
- Updates the cross-reference link in the SPAR patterns companion post

https://claude.ai/code/session_01W5ZaGUqG4Bxt1HJh7jDFkt