### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-04-23 - Astro conditional attributes
+**Learning:** In Astro components, when adding conditional HTML attributes like `aria-current`, returning `undefined` for the false state (e.g., `aria-current={condition ? "page" : undefined}`) ensures Astro cleanly omits the attribute entirely from the rendered HTML.
+**Action:** Always use `undefined` rather than `false` or `null` for omitted attributes in Astro to avoid rendering invalid states like `aria-current="false"`.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,19 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}
+        >
+          Home
+        </a>
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +40,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +49,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
### 💡 What:
Added the `aria-current="page"` attribute dynamically based on the current URL pathname to the main navigation links in `Header.astro`.

### 🎯 Why:
The links previously used a CSS class (`active`) to visually represent the current page. However, screen readers had no way to determine which link was active because the standard accessible attribute was missing.

### ♿ Accessibility:
This is a critical accessibility fix. It properly indicates the currently active page in a site's navigation menu to users employing assistive technologies (like screen readers). I used `undefined` for inactive links to ensure Astro completely omits the attribute rather than outputting invalid HTML like `aria-current="false"`.

---
*PR created automatically by Jules for task [15552004841324247188](https://jules.google.com/task/15552004841324247188) started by @robertsmieja*