### PR TITLE
🎨 Palette: Add aria-current to active header navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-04-24 - Explicit aria-current for active navigation links
+**Learning:** In Astro, navigation links tracking active routes with custom classes (e.g., `class:list={[{ active: ... }]}`) do not automatically manage accessibility state. This leaves screen reader users unaware of the current active page.
+**Action:** Always explicitly set `aria-current="page"` alongside the visual active class. Use `aria-current={condition ? "page" : undefined}` so Astro omits the attribute entirely when false.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,19 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}
+        >
+          Home
+        </a>
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +40,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +49,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
## 🎨 Palette: Explicit `aria-current` for navigation
### 💡 What:
Added `aria-current="page"` to the primary navigation links in `src/components/Header.astro` when they correspond to the currently active route. This mirrors the logic currently used for applying the visual `.active` CSS class.

### 🎯 Why:
While sighted users rely on the visual indicator (`font-weight: bold;` and underline) to recognize which page they are currently viewing, screen reader users rely on programmatic attributes to discern state. Without `aria-current`, navigation menus lack the necessary context to inform screen readers of the active page. This enhancement directly improves screen reader usability and navigability.

### ♿ Accessibility:
Explicitly binding `aria-current="page"` accurately identifies the current element within a navigation landmark for assistive technologies. We leverage Astro's component design by conditionally returning `undefined` for inactive links, which ensures the attribute is completely omitted from the rendered HTML rather than returning false or empty strings.

Also appended `.jules/palette.md` noting this architectural requirement for Astro routing logic.

---
*PR created automatically by Jules for task [7551955039598615287](https://jules.google.com/task/7551955039598615287) started by @robertsmieja*