### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-05-14 - Added aria-current to active navigation links in Astro
+**Learning:** In Astro components, links tracking active routes with custom classes (e.g. `class:list={[{ active: ... }]}`) do not automatically manage accessibility state for screen readers. Furthermore, when conditionally adding HTML attributes like `aria-current`, setting the false condition to `undefined` allows Astro to cleanly omit the attribute entirely.
+**Action:** When creating active navigation states in Astro, always explicitly pair the visual active class with `aria-current="page"` (using `undefined` for false conditions) to ensure the active state is communicated to assistive technologies.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,17 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +38,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +47,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
💡 What: Added the `aria-current="page"` attribute to navigation links in `src/components/Header.astro`. The attribute is conditionally applied to match the existing visual `active` state logic, and cleanly omitted using `undefined` when false.
🎯 Why: In Astro, visual styling for active routes (e.g., `class:list={[{ active: ... }]}`) does not automatically communicate the active state to assistive technologies. Explicitly pairing it with `aria-current="page"` ensures screen reader users also know which page they are currently on, maintaining a more intuitive and accessible experience.
📸 Before/After: Visuals remain unchanged, but the DOM now includes `aria-current="page"` on the active navigation link. Verified via screenshot and video recording during development.
♿ Accessibility: Improved navigation accessibility by explicitly identifying the current page within the navigation menu to assistive technologies.

---
*PR created automatically by Jules for task [3664088982314218411](https://jules.google.com/task/3664088982314218411) started by @robertsmieja*