### PR TITLE
⚡ Bolt: [Performance] Optimize blog post sorting with Schwartzian transform

### DIFF
--- a/src/lib/blogUtils.test.ts
+++ b/src/lib/blogUtils.test.ts
@@ -1,0 +1,19 @@
+import test from "node:test"
+import assert from "node:assert"
+import { sortPostsByDateDesc } from "./blogUtils.ts"
+
+test("sortPostsByDateDesc sorts posts in descending order by date", () => {
+  const posts = [
+    { id: 1, data: { date: "2023-01-01" } },
+    { id: 2, data: { date: "2023-01-03" } },
+    { id: 3, data: { date: "2023-01-02" } },
+  ]
+
+  const sorted = sortPostsByDateDesc(posts)
+
+  assert.deepStrictEqual(sorted, [
+    { id: 2, data: { date: "2023-01-03" } },
+    { id: 3, data: { date: "2023-01-02" } },
+    { id: 1, data: { date: "2023-01-01" } },
+  ])
+})

--- a/src/lib/blogUtils.ts
+++ b/src/lib/blogUtils.ts
@@ -1,0 +1,22 @@
+/**
+ * ⚡ Bolt Optimization:
+ * Repeated `Date` instantiation within sort comparators for blog collections
+ * is a performance bottleneck (O(N log N)). This utility uses a map-sort-map
+ * pattern (Schwartzian transform) to cache parsed date values, reducing
+ * date parsing to O(N).
+ */
+export function sortPostsByDateDesc<
+  T extends { data: { date: Date | string } },
+>(posts: T[]): T[] {
+  // Map phase: parse and cache the date values
+  const withDates = posts.map((post) => ({
+    post,
+    dateValue: new Date(post.data.date).valueOf(),
+  }))
+
+  // Sort phase: sort the cached values
+  withDates.sort((a, b) => b.dateValue - a.dateValue)
+
+  // Map phase: extract original objects
+  return withDates.map((item) => item.post)
+}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -2,11 +2,10 @@
 import { getCollection } from "astro:content"
 import Layout from "../../layouts/Layout.astro"
 import Giscus from "../../components/Giscus.astro"
+import { sortPostsByDateDesc } from "../../lib/blogUtils"
 
 export async function getStaticPaths() {
-  const posts = (await getCollection("blog")).sort(
-    (a, b) => new Date(b.data.date).valueOf() - new Date(a.data.date).valueOf()
-  )
+  const posts = sortPostsByDateDesc(await getCollection("blog"))
   return posts.map((post, index) => ({
     params: { slug: post.slug },
     props: {

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,10 +1,9 @@
 ---
 import { getCollection } from "astro:content"
 import Layout from "../../layouts/Layout.astro"
+import { sortPostsByDateDesc } from "../../lib/blogUtils"
 
-const posts = (await getCollection("blog")).sort(
-  (a, b) => new Date(b.data.date).valueOf() - new Date(a.data.date).valueOf()
-)
+const posts = sortPostsByDateDesc(await getCollection("blog"))
 ---
 
 <Layout

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -2,11 +2,10 @@ import rss from "@astrojs/rss"
 import { getCollection } from "astro:content"
 import { SITE_TITLE, SITE_DESCRIPTION } from "../consts"
 import type { APIContext } from "astro"
+import { sortPostsByDateDesc } from "../lib/blogUtils"
 
 export async function GET(context: APIContext) {
-  const posts = (await getCollection("blog")).sort(
-    (a, b) => new Date(b.data.date).valueOf() - new Date(a.data.date).valueOf()
-  )
+  const posts = sortPostsByDateDesc(await getCollection("blog"))
 
   return rss({
     title: `${SITE_TITLE}'s Blog RSS Feed`,


### PR DESCRIPTION
💡 What: Replaced the inline sorting logic for blog posts in `getCollection` with a new `sortPostsByDateDesc` utility that uses a map-sort-map pattern (Schwartzian transform). Added generic typing to preserve prototype methods like `.render()` and added a unit test.

🎯 Why: The original sorting mechanism repeatedly instantiated `Date` objects inside the `.sort()` comparator, resulting in $O(N \log N)$ date parsing operations, which is a performance bottleneck for static site generation as the number of posts grows. 

📊 Impact: Reduces date instantiation and parsing from $O(N \log N)$ to exactly $O(N)$. This provides an unblocked measurable speedup during `astro build` operations when fetching collections.

🔬 Measurement: Verify via unit tests `node --experimental-strip-types --test src/lib/blogUtils.test.ts` or by running `pnpm build` to observe successful static site generation.

---
*PR created automatically by Jules for task [13650448763009195580](https://jules.google.com/task/13650448763009195580) started by @robertsmieja*