### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-04-28 - Added `aria-current` to active navigation links
+**Learning:** In Astro, navigation links tracking active routes with custom classes (e.g., `class:list={[{ active: ... }]}`) do not automatically manage accessibility state. This leaves screen reader users unaware of which page they are currently on.
+**Action:** Explicitly set `aria-current="page"` alongside the visual active class. When conditionally adding HTML attributes like `aria-current`, set the false condition to `undefined` (e.g., `aria-current={condition ? "page" : undefined}`) so Astro cleanly omits the attribute entirely from the rendered HTML.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,19 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}
+        >
+          Home
+        </a>
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +40,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +49,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
* 💡 What: Added the `aria-current="page"` attribute to active navigation links in the header.
* 🎯 Why: This helps screen reader users understand which page they are currently on. The visual active state was present, but the semantic accessibility state was missing.
* ♿ Accessibility: Fixes missing `aria-current` state for the current page link.

---
*PR created automatically by Jules for task [8588606239297548763](https://jules.google.com/task/8588606239297548763) started by @robertsmieja*