### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-05-02 - Ensure aria-current is explicitly set on active navigation links
+**Learning:** This app's navigation links tracking active routes used custom classes like `class:list={[{ active: ... }]}` but did not automatically manage accessibility state. Screen readers had no semantic indication of the currently active page.
+**Action:** When tracking the active navigation route with visual classes, always explicitly set `aria-current="page"` (using undefined for false cases so Astro cleanly omits the attribute) to properly inform screen readers of the active context.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,17 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +38,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +47,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
* 💡 **What:** Added `aria-current="page"` to the Header component navigation links conditionally, mirroring the logic used for the `.active` class.
* 🎯 **Why:** To improve accessibility. Currently, the active link receives visual styling (`.active` class and bold text), but screen readers have no semantic indication of which navigation item is the active page.
* ♿ **Accessibility:** Users using screen readers will now have the current page correctly announced, preventing confusion and improving the overall navigational experience. Added an entry to `.jules/palette.md` to establish this as a standard practice for future development.

---
*PR created automatically by Jules for task [9175635630873625004](https://jules.google.com/task/9175635630873625004) started by @robertsmieja*