### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+## 2024-05-03 - Added aria-current to active navigation
+**Learning:** In Astro navigation components, applying an `active` CSS class provides visual feedback, but it does not convey the active state to screen readers.
+**Action:** Always add the semantic `aria-current="page"` attribute to navigation links alongside any visual `active` state toggling. In Astro, use `condition ? "page" : undefined` to cleanly render or omit the attribute.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,19 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}
+        >
+          Home
+        </a>
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +40,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +49,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
💡 What: Added `aria-current="page"` attribute to active navigation links in `Header.astro`.
🎯 Why: Enhances accessibility by explicitly communicating the current page context to screen reader users, complementing the existing visual "active" class styling.
♿ Accessibility: Improves WCAG compliance for navigation menus by providing semantic state information.

---
*PR created automatically by Jules for task [17044038426125742740](https://jules.google.com/task/17044038426125742740) started by @robertsmieja*