### PR TITLE
🎨 Palette: Add `aria-current` to active navigation links for screen readers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2026-05-05 - Added aria-current to active navigation links
+**Learning:** Visual active states (like CSS classes) in navigation menus do not automatically convey accessibility state to screen readers.
+**Action:** Always pair visual active classes with `aria-current="page"` (or appropriately setting it to undefined when not active) in navigation components to ensure screen readers correctly announce the active page.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,17 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +38,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +47,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
**Palette 🎨 - UX/Accessibility Enhancement**

### 💡 What:
Added the `aria-current="page"` attribute to the active navigation link in `src/components/Header.astro`. The attribute dynamically evaluates to `"page"` if the route is active, and `undefined` if not (allowing Astro to cleanly omit it).

### 🎯 Why:
While the navigation menu currently uses a CSS class (`.active`) to visually indicate the current page (e.g., via bold text and an underline), this visual state is not automatically conveyed to screen readers. By adding `aria-current="page"`, assistive technologies will now explicitly announce the active page, significantly improving spatial awareness and navigation for visually impaired users.

### ♿ Accessibility:
*   Screen readers (like NVDA, VoiceOver, JAWS) will now read the active link as "Home, current page, link" (or similar), instead of just "Home, link".
*   This explicitly solves a WCAG failure related to not programmatically indicating the current state of a navigation item.

Also added a journal entry to `.jules/palette.md` to document this critical learning.

---
*PR created automatically by Jules for task [16711282021967626949](https://jules.google.com/task/16711282021967626949) started by @robertsmieja*