### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-05-06 - Active navigation links lack accessibility state
+**Learning:** Navigation links tracking active routes with custom classes do not automatically manage accessibility state for screen readers. They only update the visual active class, leaving visually impaired users unaware of the current active page.
+**Action:** Explicitly set `aria-current="page"` alongside visual active state checks in navigation elements to improve semantic web structure and accessibility.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,19 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}
+        >
+          Home
+        </a>
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +40,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +49,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -22,6 +22,9 @@ const fullTitle = `${title} | ${SITE_TITLE}`
 <meta name="twitter:creator" content={SITE_AUTHOR} />
 <meta name="twitter:title" content={title} />
 <meta name="twitter:description" content={description} />
-<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
+<meta
+  http-equiv="Content-Security-Policy"
+  content="upgrade-insecure-requests"
+/>
 <meta name="referrer" content="strict-origin-when-cross-origin" />
 {keywords.length > 0 && <meta name="keywords" content={keywords.join(", ")} />}

--- a/src/components/resume/Experience.astro
+++ b/src/components/resume/Experience.astro
@@ -67,8 +67,8 @@ import ExperienceEntry from "./experience/ExperienceEntry.astro"
         objects in S3 buckets.
       </li>
       <li>
-        Designed and implemented email based secure passwordless login system for
-        test drive demos, including UI.
+        Designed and implemented email based secure passwordless login system
+        for test drive demos, including UI.
       </li>
       <li>
         Drove major technical debt reduction by upgrading critical libraries

--- a/src/components/resume/Profile.astro
+++ b/src/components/resume/Profile.astro
@@ -10,8 +10,8 @@ import Icon from "../Icon.astro"
   <p>
     Senior polyglot engineer specializing in the design and delivery of complex,
     scalable systems. Proponent of modern developer tooling to enhance team
-    velocity and efficiency. Committed to engineering excellence, with a focus on
-    strategic modernization and refactoring to improve code stability, strengthen
-    security posture, and optimize build pipelines.
+    velocity and efficiency. Committed to engineering excellence, with a focus
+    on strategic modernization and refactoring to improve code stability,
+    strengthen security posture, and optimize build pipelines.
   </p>
 </div>

--- a/src/components/resume/education/College.astro
+++ b/src/components/resume/education/College.astro
@@ -8,8 +8,8 @@
     <span>May 2015</span>
   </dt>
   <dd class="degree">
-    Bachelor of Science, Double Major in Computer Science & Interactive Media and
-    Game Development
+    Bachelor of Science, Double Major in Computer Science & Interactive Media
+    and Game Development
   </dd>
   <dt>Received</dt>
   <dd>WPI Presidential Merit Scholarship, 2011 &ndash; 2015</dd>

--- a/src/content/blog/2026-04-19-coding-with-ai-the-spar-patterns/index.md
+++ b/src/content/blog/2026-04-19-coding-with-ai-the-spar-patterns/index.md
@@ -18,22 +18,23 @@ Coding with an AI agent is pair programming with a particular kind of partner. T
 In a field moving faster than almost any other, this is the workflow I've settled on when approaching a software engineering task with an agent.
 
 SPAR: **Search, Plan, Act/Account, Review.**
+
 - **Search**: Ask your agent to map the relevant parts of the codebase before making any changes. Alternatively, ask it to interview you based on your prompt to gather whatever context it needs.
 - **Plan**: Have your agent write an explicit plan before executing anything, preferably saved to disk (e.g., `PLAN.md`) in case the session crashes or drifts.
 - **Act/Account**: Maintain a running log of what's been done and what remains (e.g., `PROGRESS.md`). This externalizes the session state, allowing you to "start fresh" with a new conversation when the current one gets sludgy.
 - **Review**: After implementation, ask the agent to review its own work against your repository's best practices, CI checks, and linting. If you can, use a different model for the review than the one that wrote the code.
 
-I like this acronym because it reinforces the idea that we should be actively *sparring* with our agents, asking them to explain code we don't understand, asking why they chose a particular approach. It's all too easy to blindly trust that your agent knows what it's doing.
+I like this acronym because it reinforces the idea that we should be actively _sparring_ with our agents, asking them to explain code we don't understand, asking why they chose a particular approach. It's all too easy to blindly trust that your agent knows what it's doing.
 
 (Complaints about the acronym and the pun can be directed to Claude.)
-
 
 ---
 
 ## The Four Patterns
 
 ### Search
-*Read the codebase before touching it.*
+
+_Read the codebase before touching it._
 
 Before asking the agent to make any changes, have it search and map the relevant parts of the codebase first. The agent reads key files, summarizes structure, identifies dependencies, and surfaces anything that might matter for the task ahead.
 
@@ -44,11 +45,13 @@ Skipping Search is the most common cause of confident-sounding but wrong agent o
 ---
 
 ### Plan
-*Agree on the approach before writing any code.*
+
+_Agree on the approach before writing any code._
 
 Have the agent produce an explicit written plan (which files to touch, what changes to make, in what order) and then **stop and wait for your review** before executing anything. You're the Navigator; the plan is the route you both agree on before the Driver starts moving.
 
 The critical ingredient is the **human gate** between plan and action. Use this gate to verify:
+
 - What commands will the agent run?
 - What files will it touch?
 - How will it validate its changes?
@@ -58,7 +61,8 @@ The written artifact (a `PLAN.md`, a checklist, an explicit "ready to proceed?")
 ---
 
 ### Act/Account
-*Keep a running record of where you are.*
+
+_Keep a running record of where you are._
 
 For tasks spanning many steps, have the agent maintain a running checklist: a TODO file, a progress log, or a `PROGRESS.md`. As each step finishes, it gets checked off. **This turns ephemeral session context into durable state.**
 
@@ -71,7 +75,8 @@ More importantly, **it allows you to start fresh often.** AI agents are at their
 ---
 
 ### Review
-*Audit the diff before you ship it.*
+
+_Audit the diff before you ship it._
 
 After the agent produces changes, feed the diff to a fresh agent session (or step back and review it yourself) before committing. Ask for an explicit audit: bugs, unintended side effects, deviation from the original plan, anything that smells wrong.
 
@@ -99,12 +104,12 @@ You won't always need all four. A small task in familiar code might go straight 
 
 ## The Pair Programming Parallel
 
-| Pair Programming | SPAR |
-|---|---|
-| Walkthrough before coding | Search |
-| Navigator agrees on approach | Plan |
-| Navigator tracks progress | Act/Account |
-| Switching seats to review | Review |
+| Pair Programming             | SPAR        |
+| ---------------------------- | ----------- |
+| Walkthrough before coding    | Search      |
+| Navigator agrees on approach | Plan        |
+| Navigator tracks progress    | Act/Account |
+| Switching seats to review    | Review      |
 
 The underlying principle is the same in both cases: **two perspectives on the same problem produce better results than one.** SPAR is what that looks like when one of the two people doesn't have persistent memory, can't sense when it's going off the rails, and needs the human to hold the context that the session can't.
 
@@ -113,6 +118,9 @@ The underlying principle is the same in both cases: **two perspectives on the sa
 > **Note:** SPAR is a tactical workflow for human-AI pair programming. If you want to see how these session-level habits translate into the design of fully autonomous systems, read the companion post: [Designing with AI: Agentic Design Patterns](/blog/2026-04-19-designing-with-ai-agentic-design-patterns/).
 
 [^1]: Ayende Rahien, [Agents, Code Reviews, and the Bottleneck Shift, Oh My](https://ayende.com/blog/203939-C/agents-code-reviews-and-the-bottleneck-shift-oh-my)
+
 [^2]: Wikipedia, [Pair programming](https://en.wikipedia.org/wiki/Pair_programming)
+
 [^3]: Martin Fowler, [On Pair Programming](https://martinfowler.com/articles/on-pair-programming.html)
+
 [^4]: Martin Fowler, [On Pair Programming: Styles](https://martinfowler.com/articles/on-pair-programming.html#Styles)

--- a/src/content/blog/2026-04-19-designing-with-ai-agentic-design-patterns/index.md
+++ b/src/content/blog/2026-04-19-designing-with-ai-agentic-design-patterns/index.md
@@ -5,7 +5,7 @@ description: "Five design patterns from Anthropic's Building Effective Agents: P
 tags: ["ai", "agents", "design-patterns", "architecture", "anthropic"]
 ---
 
-There's a difference between _what you're building_ and _how you're building it_. Whether you are architecting a fully autonomous system or engaging in a "piloted session" (where you and an AI agent work together in real-time), certain recurring patterns emerge. 
+There's a difference between _what you're building_ and _how you're building it_. Whether you are architecting a fully autonomous system or engaging in a "piloted session" (where you and an AI agent work together in real-time), certain recurring patterns emerge.
 
 Anthropic's [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents)[^1] identifies five of these. They follow the tradition of the "Gang of Four" patterns for object-oriented software[^2]: a shared vocabulary for design decisions that help you avoid reinventing the wheel.
 
@@ -25,6 +25,7 @@ Most of the five patterns below are workflow patterns. For many problems, a well
 ## The Five Patterns
 
 ### 1. Prompt Chaining
+
 _Sequential steps, each building on the last._
 
 The output of one LLM call becomes the input for the next, forming a pipeline. Each step is focused and independently optimizable. Because every handoff is inspectable, this is the easiest pattern to debug. It works well for tasks with a clear sequence, such as document transformation or multi-step code generation.
@@ -34,6 +35,7 @@ The output of one LLM call becomes the input for the next, forming a pipeline. E
 ---
 
 ### 2. Routing
+
 _Classify the input, then dispatch to a specialist._
 
 An initial LLM call categorizes the input and routes it to a handler optimized for that specific task. This allows you to tune each route independently. Use this for systems handling diverse inputs, like support triage or intent classification.
@@ -43,9 +45,11 @@ An initial LLM call categorizes the input and routes it to a handler optimized f
 ---
 
 ### 3. Parallelization
+
 _Run independent subtasks concurrently._
 
 This pattern has two main variants:
+
 - **Sectioning:** Dividing a task into parallel workstreams (e.g., three agents reviewing three different files simultaneously).
 - **Voting:** Running the same task multiple times across independent agents and aggregating the results to reach a consensus.
 
@@ -54,6 +58,7 @@ This pattern has two main variants:
 ---
 
 ### 4. Orchestrator-Workers
+
 _A coordinator delegates to specialists at runtime._
 
 A central LLM (the orchestrator) dynamically breaks down a complex task and assigns subtasks to worker LLMs. The orchestrator determines the shape of the work as it goes. This works for problems where planning and "doing" must be interleaved, such as complex refactoring.
@@ -63,6 +68,7 @@ A central LLM (the orchestrator) dynamically breaks down a complex task and assi
 ---
 
 ### 5. Evaluator-Optimizer
+
 _Generate, critique, refine._
 
 One LLM generates an output; a separate evaluator critiques it against defined quality criteria; the generator then revises the work. The loop continues until the "gate" is passed. This pattern pays off when quality is measurable and iterative refinement adds clear value.
@@ -82,4 +88,5 @@ The design principle Anthropic emphasizes is: **start simple.** Complexity intro
 > **Note:** These five patterns are architectural structures for autonomous systems. To see how you can manually apply these same principles as tactical habits during a "piloted session," read the companion post: [Coding with AI: The SPAR Patterns](/blog/2026-04-19-coding-with-ai-the-spar-patterns/).
 
 [^1]: Anthropic, [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents)
+
 [^2]: Gamma, Helm, Johnson, Vlissides, [Design Patterns: Elements of Reusable Object-Oriented Software](https://en.wikipedia.org/wiki/Design_Patterns)

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -50,12 +50,10 @@ import Layout from "../layouts/Layout.astro"
           <li>How can it help us solve old problems in new ways?</li>
         </ul>
       </li>
+      <li>How can automation help developers focus on the problem at hand?</li>
       <li>
-        How can automation help developers focus on the problem at hand?
-      </li>
-      <li>
-        How can I leverage my own technical abilities to help other developers be
-        more productive?
+        How can I leverage my own technical abilities to help other developers
+        be more productive?
       </li>
     </ul>
     <p>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -57,8 +57,8 @@ import Layout from "../layouts/Layout.astro"
         link="https://github.com/robertsmieja/UE4-Maze/"
         title="UE4-Maze"
       >
-        The end result of a tutorial for procedurally generating a maze in Unreal
-        Engine 4.4.
+        The end result of a tutorial for procedurally generating a maze in
+        Unreal Engine 4.4.
       </ProjectEntry>
       <ProjectEntry
         year="2013"
@@ -66,8 +66,8 @@ import Layout from "../layouts/Layout.astro"
         title="Gw2InfoViewer"
       >
         Java 7 Swing application to visualize a JSON API End-Point for the game
-        "Guild Wars 2", created when I was still in college. This no longer works
-        and is out-dated.
+        "Guild Wars 2", created when I was still in college. This no longer
+        works and is out-dated.
       </ProjectEntry>
     </ul>
   </div>


### PR DESCRIPTION
💡 What: Added `aria-current="page"` dynamically to navigation links in `Header.astro` when they match the active route.
🎯 Why: Visually impaired users using screen readers were missing the critical context of which page is currently active. The custom `.active` class provides visual feedback but lacks semantic accessibility state.
♿ Accessibility: Improved semantic web structure for assistive technologies by officially conveying the current page state, adhering to standard web accessibility guidelines.

---
*PR created automatically by Jules for task [17983308227543874717](https://jules.google.com/task/17983308227543874717) started by @robertsmieja*