### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-18 - Standardize External Links with Reusable Component
 **Learning:** This app previously contained multiple plain `<a>` tags with `target="_blank"` scattered across pages (e.g., `index.tsx`, `projectEntry.tsx`). These links lacked visual indicators showing they open in new tabs, and many lacked descriptive `aria-label`s, which is bad for accessibility (screen readers need to warn users about context changes).
 **Action:** Created a reusable `<ExternalLink>` component that standardizes external links. It forces `target="_blank"` and `rel="noopener noreferrer"`, visually appends a decorative FontAwesome external link icon (`faExternalLinkAlt` with `aria-hidden="true"`), and requires an `ariaLabel` prop (e.g., "GitHub (opens in a new tab)"). Always use this component for external links to ensure consistent UX and accessibility.
+
+## 2026-05-09 - Active Navigation Link Accessibility
+**Learning:** Navigation links that visually indicate the current active route using custom classes (like `.active`) do not automatically convey this state to screen readers, leaving visually impaired users unaware of their current location within the navigation.
+**Action:** Always pair visual active state classes with `aria-current="page"` (using `aria-current={condition ? "page" : undefined}` in Astro so it cleanly omits when false) to ensure screen readers correctly announce the active page.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,17 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +38,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +47,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
Added `aria-current="page"` to the active navigation links in the header for improved screen reader accessibility. Documented this UX improvement in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [4465678321573929585](https://jules.google.com/task/4465678321573929585) started by @robertsmieja*