### PR TITLE
🎨 Palette: Add aria-current="page" to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2026-05-13 - Added aria-current="page" to active navigation links
+**Learning:** Visual active states (like an `.active` class) on navigation links are not announced by screen readers, meaning visually impaired users don't know which page is currently active.
+**Action:** Always pair visual active classes on navigation links with `aria-current="page"` to ensure screen readers announce the active route correctly. Use ternary operators (e.g. `aria-current={isActive ? "page" : undefined}`) to cleanly omit the attribute when false.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,19 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}
+        >
+          Home
+        </a>
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +40,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +49,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
💡 What: Added `aria-current="page"` to the active navigation links in `Header.astro`.
🎯 Why: Visual active states (like the `.active` class) on navigation links are not announced by screen readers, meaning visually impaired users do not know which page is currently active. Pairing the visual active state with `aria-current="page"` ensures screen readers announce the active route correctly.
♿ Accessibility: Ensures that screen reader users are aware of the currently active navigation item, improving the overall navigational accessibility of the site.

---
*PR created automatically by Jules for task [6207943211886053637](https://jules.google.com/task/6207943211886053637) started by @robertsmieja*