### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2025-01-20 - Added aria-current to navigation links
+**Learning:** Visual active states (like `class="active"`) do not automatically manage accessibility state for screen readers, leaving visually impaired users without important context about their location.
+**Action:** Always pair visual active classes on navigation items with `aria-current="page"` (using undefined for false conditions) to ensure screen readers can announce the current active route.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,17 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +38,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +47,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
🎨 Palette: [UX improvement] - Added aria-current to navigation links

💡 What: Added `aria-current="page"` attribute to active navigation links in the header, mirroring the existing visual `active` class logic. Used `undefined` for inactive links to cleanly omit the attribute from the rendered HTML.
🎯 Why: Visual active states alone (like CSS classes with font-weight or underline) do not communicate state to screen readers. Adding this ARIA attribute ensures visually impaired users navigating via assistive technology understand their current location in the site hierarchy.
♿ Accessibility: Improves WCAG 2.1 SC 4.1.2 Name, Role, Value compliance by explicitly communicating the current page state to assistive technologies.

---
*PR created automatically by Jules for task [18189930994674288409](https://jules.google.com/task/18189930994674288409) started by @robertsmieja*