### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-05-18 - Added aria-current to active navigation links
+**Learning:** Visual indicators for active navigation links (like bold text or underlining) are not automatically announced to screen readers. Relying solely on CSS classes for active state fails accessibility guidelines.
+**Action:** Always pair visual active classes on navigation links with the explicit attribute aria-current={condition ? "page" : undefined} to ensure assistive technologies correctly announce the active page.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,17 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +38,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +47,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
💡 What: Added the `aria-current="page"` attribute conditionally to navigation links based on the active pathname.
🎯 Why: To explicitly announce to screen reader users which navigation link corresponds to the currently active page, matching the visual indication provided by the CSS `active` class.
♿ Accessibility: Ensures compliance with WCAG guidelines for indicating current page location within navigation menus, providing a more intuitive and accessible experience for users of assistive technology.

---
*PR created automatically by Jules for task [6693783092501517981](https://jules.google.com/task/6693783092501517981) started by @robertsmieja*