### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+## 2024-05-19 - Added aria-current to active navigation links
+**Learning:** Visual indicators of active navigation state (like bold text or underlines) are not conveyed to screen readers automatically. Without explicit ARIA attributes, visually impaired users cannot easily determine their current location within the site's navigation structure.
+**Action:** Always pair visual active classes on navigation links with `aria-current="page"` (conditionally setting it to undefined when false in Astro) to ensure accessibility state matches the visual state.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,17 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +38,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +47,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
🎨 **Palette: Add `aria-current` to active navigation links**

**💡 What:** Added the `aria-current="page"` attribute to navigation links in the `<Header />` component when the corresponding route is active. The attribute is conditionally omitted using Astro's `undefined` behavior when the link is not active.

**🎯 Why:** While the current navigation uses a visual indicator (bold text via the `.active` class) to show the user which page they are currently on, this information was not being conveyed programmatically to assistive technologies like screen readers. This leaves visually impaired users without a clear understanding of their location within the site's primary navigation.

**♿ Accessibility:** Improves navigation accessibility by properly identifying the currently active item in the navigation list to screen readers, complying with standard WCAG requirements for conveying state.

*Journal updated to record this learning.*

---
*PR created automatically by Jules for task [1718391686711885483](https://jules.google.com/task/1718391686711885483) started by @robertsmieja*