### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-05-22 - Added aria-current to active navigation links
+**Learning:** Active state styling via CSS classes provides visual feedback but fails to communicate the current page to screen readers, breaking navigational context for visually impaired users.
+**Action:** Always apply `aria-current="page"` to the active link within navigation components alongside visual active state classes.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,19 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}
+        >
+          Home
+        </a>
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +40,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +49,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
💡 **What:** Added the `aria-current="page"` attribute to the active navigation link in `Header.astro`.
🎯 **Why:** Previously, the active navigation link was indicated solely by a visual CSS class (`.active`). This visual cue is invisible to screen readers, leaving visually impaired users without context about their current location within the navigation structure.
♿ **Accessibility:** This directly addresses an accessibility deficiency by using semantic HTML attributes (`aria-current`) to programmatically indicate the active state, strictly following ARIA guidelines for navigation components.

The `.jules/palette.md` journal has also been updated with this learning to ensure future navigation menus include semantic active states alongside visual ones.

---
*PR created automatically by Jules for task [12879815983231021032](https://jules.google.com/task/12879815983231021032) started by @robertsmieja*