### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2026-05-24 - Convey active route state to screen readers
+**Learning:** Navigation links tracking active routes visually (e.g. with an "active" class) do not automatically convey this state to screen readers, causing accessibility issues.
+**Action:** Always add `aria-current="page"` (using conditional rendering like `aria-current={condition ? "page" : undefined}`) to navigation links that represent the currently active route.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,19 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}
+        >
+          Home
+        </a>
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +40,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +49,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
💡 What: Added `aria-current="page"` to active navigation links in the header.
🎯 Why: To properly convey the active navigation state to screen readers, improving overall accessibility.
📸 Before/After: N/A (non-visual structural accessibility change).
♿ Accessibility: Improved screen reader experience by programmatically indicating the current page in the main navigation menu using native ARIA attributes.

---
*PR created automatically by Jules for task [5156162155813721320](https://jules.google.com/task/5156162155813721320) started by @robertsmieja*