### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+## 2024-05-25 - Added aria-current to active navigation links
+**Learning:** Visual indicators for active navigation states (like bold text or underlines) are not announced by screen readers. Additionally, in Astro, setting an attribute to `false` might render it as `"false"`, while setting it to `undefined` cleanly omits it from the DOM.
+**Action:** Always explicitly set `aria-current="page"` alongside visual active classes, and conditionally render it to `undefined` when not active to ensure clean HTML and proper screen reader announcements.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,19 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}
+        >
+          Home
+        </a>
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +40,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +49,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
💡 **What:** Added `aria-current="page"` to navigation links when they correspond to the active route.
🎯 **Why:** Screen reader users need semantic feedback about their current location, as visual active indicators (like bolding) are not announced.
📸 **Before/After:** Not applicable (purely an accessibility change, no visual difference).
♿ **Accessibility:** Explicitly provides state to assistive technologies, complying with WCAG success criteria for navigation location.

---
*PR created automatically by Jules for task [14457285818100740180](https://jules.google.com/task/14457285818100740180) started by @robertsmieja*