### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-05-24 - Added aria-current to active navigation links
+**Learning:** Visual active states (like CSS classes) on navigation links are not sufficient for screen reader users to understand their current location within a site.
+**Action:** Always pair visual active classes with `aria-current="page"` to ensure equal access to navigational context.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,17 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +38,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +47,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
💡 What: Added the `aria-current="page"` attribute to navigation links in the header when their corresponding route is active.
🎯 Why: While sighted users can see the active navigation item through visual styling (bold text and underline), screen reader users rely on semantic attributes. Adding `aria-current` provides crucial contextual information to assistive technologies about the user's current location within the site.
📸 Before/After: Visual presentation is unchanged. The improvement is strictly at the semantic HTML level.
♿ Accessibility: Ensures WCAG compliance and equal access to navigation context by explicitly conveying the active page state to assistive technologies.

---
*PR created automatically by Jules for task [16847554653251423090](https://jules.google.com/task/16847554653251423090) started by @robertsmieja*