### PR TITLE
🎨 Palette: Add aria-current to navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-05-29 - Navigation Active State Accessibility
+**Learning:** In Astro, visual active classes on navigation links do not automatically manage accessibility state for screen readers.
+**Action:** Always pair visual active classes with `aria-current="page"` (using `condition ? "page" : undefined` to cleanly omit when false) on primary navigation elements.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,19 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}
+        >
+          Home
+        </a>
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +40,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +49,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
💡 **What:** Added `aria-current={... ? "page" : undefined}` dynamically to the primary navigation links in `src/components/Header.astro`. Added a journal entry to `.jules/palette.md` to document the learning.
🎯 **Why:** To ensure that screen readers and assistive technologies announce the active routing state of navigation links properly. The visual `active` class is not sufficient for accessibility.
📸 **Before/After:** Not a visual change (accessibility only). Screenshot generated using Playwright confirms correct HTML output (`aria-current="page"` attached to the active link).
♿ **Accessibility:** This directly improves keyboard and screen-reader accessibility by implementing the standard ARIA state attribute for active routes.

---
*PR created automatically by Jules for task [5046844198463434942](https://jules.google.com/task/5046844198463434942) started by @robertsmieja*