### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-05-30 - Added aria-current="page" to active navigation links
+**Learning:** Adding an `active` CSS class to navigation links provides visual feedback, but it does not convey the current active page state to screen readers.
+**Action:** Always include `aria-current="page"` (conditionally set to `"page"` or `undefined`) on navigation links that indicate the currently active route to ensure screen reader users receive the same context as sighted users.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" class:list={[{ active: pathname === "/" }]} aria-current={pathname === "/" ? "page" : undefined}>Home</a>
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +34,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +43,13 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]} aria-current={pathname === "/resume/" ? "page" : undefined}>
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
💡 What: Added `aria-current="page"` to active navigation links in the header.
🎯 Why: To convey the active page state to screen reader users, matching the visual indication provided by the `active` CSS class.
📸 Before/After: N/A
♿ Accessibility: Improved screen reader support for main navigation by programmatically identifying the currently active page.

---
*PR created automatically by Jules for task [6151816275206747789](https://jules.google.com/task/6151816275206747789) started by @robertsmieja*