### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-06-02 - Added aria-current to active navigation links
+**Learning:** Visual active states on navigation links (like custom `active` classes) do not convey state to screen readers. Relying solely on CSS classes for active links creates an accessibility gap.
+**Action:** Always pair visual active classes with `aria-current="page"` (conditionally set to `undefined` when false in Astro) to ensure navigation state is accessible to all users.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,19 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}
+        >
+          Home
+        </a>
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +40,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +49,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
💡 What: Added `aria-current="page"` to the currently active navigation link in the site header. Conditionally set to `undefined` in Astro for inactive links.
🎯 Why: Relying solely on a visual CSS `active` class creates an accessibility gap. Screen reader users need semantic indicators to know which page is currently active.
📸 Before/After: Visual presentation remains exactly the same, but the DOM now includes the appropriate `aria-current` attribute.
♿ Accessibility: Improves navigation accessibility for screen reader users by programmatically exposing the active route state.

---
*PR created automatically by Jules for task [195481733360606164](https://jules.google.com/task/195481733360606164) started by @robertsmieja*