### PR TITLE
🎨 Palette: Add aria-current to navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+## 2024-06-03 - Setting aria-current correctly in Astro
+**Learning:** In Astro components, you should set false conditions for attributes like `aria-current` to `undefined` instead of `false` or an empty string, so that Astro entirely omits the attribute from the rendered HTML.
+**Action:** Always use `condition ? "page" : undefined` for boolean or stateful ARIA attributes in `.astro` files.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,19 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}
+        >
+          Home
+        </a>
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +40,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +49,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
💡 What: Added the `aria-current="page"` attribute to navigation links when they correspond to the currently active route. Set the attribute to `undefined` for inactive links so Astro completely omits it from the DOM.
🎯 Why: Screen reader users need semantic feedback to know which page in the navigation menu represents their current location. The visual `active` class handles sighted users, but a programmatic indicator was missing.
📸 Before/After: Before, `<a href="/" class="active">Home</a>`. After: `<a href="/" class="active" aria-current="page">Home</a>`.
♿ Accessibility: Ensures that users relying on assistive technology can clearly identify their location within the site's primary navigation.

---
*PR created automatically by Jules for task [5311953837048382397](https://jules.google.com/task/5311953837048382397) started by @robertsmieja*