### PR TITLE
🎨 Palette: Add aria-current to navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+## 2024-06-04 - Added aria-current to active navigation links
+**Learning:** Screen readers need semantic HTML attributes like `aria-current="page"` to understand which navigation link represents the currently active page. CSS classes like `.active` only provide visual cues.
+**Action:** Always add `aria-current="page"` to the currently active link within a navigation menu.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,19 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}
+        >
+          Home
+        </a>
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +40,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +49,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
💡 **What:** Added the `aria-current="page"` attribute conditionally to active links in the main navigation header.

🎯 **Why:** To improve accessibility. Screen readers use semantic HTML attributes like `aria-current` to communicate which page the user is currently on within a navigation block. CSS classes like `.active` only provide visual cues.

📸 **Before/After:** No visual changes. The modification only affects the underlying semantic HTML structure.

♿ **Accessibility:** This directly addresses an accessibility concern by making the active navigation state readable by assistive technologies, ensuring a better experience for users relying on screen readers.

---
*PR created automatically by Jules for task [10061857033931176531](https://jules.google.com/task/10061857033931176531) started by @robertsmieja*