### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+## 2024-06-06 - Added aria-current to active navigation links
+**Learning:** For single-page applications or static sites built with Astro where navigation active states are applied via CSS classes (e.g., `class="active"`), screen readers cannot natively announce the currently active page. Relying solely on visual cues excludes visually impaired users.
+**Action:** Always conditionally append `aria-current="page"` (using `aria-current={condition ? "page" : undefined}` in Astro to ensure omitted output when false) to navigation links alongside any visual `active` class to provide proper context to assistive technologies.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,19 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}
+        >
+          Home
+        </a>
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +40,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +49,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
💡 What:
Added the `aria-current="page"` attribute to the active navigation links in the header.

🎯 Why:
While the navigation menu visually indicates the current page using bold styling (`class="active"`), screen readers and assistive technologies do not natively understand this visual cue. 

📸 Before/After:
Before: `<a href="/" class="active">Home</a>`
After: `<a href="/" class="active" aria-current="page">Home</a>`

♿ Accessibility:
The `aria-current="page"` attribute explicitly communicates to screen readers which link represents the currently viewed page, significantly improving context and navigation for visually impaired users. In Astro, the attribute is safely omitted when not active (`undefined`).

---
*PR created automatically by Jules for task [17570430289647263780](https://jules.google.com/task/17570430289647263780) started by @robertsmieja*