### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+## 2024-06-07 - Added aria-current to active navigation links
+**Learning:** Visual cues for active navigation states (like bold text or underlines) are inaccessible to screen reader users. Without semantic indication, visually impaired users cannot easily determine which page they are currently on within a navigation menu.
+**Action:** Always conditionally apply `aria-current="page"` to active navigation links to ensure parity between visual and semantic state.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,19 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}
+        >
+          Home
+        </a>
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +40,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +49,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>


### PR DESCRIPTION
💡 What: Added the `aria-current="page"` attribute conditionally to all active navigation links in `Header.astro`. Added a new critical learning entry to `.jules/palette.md` explaining why this is important.
🎯 Why: To improve semantic representation of the application's state. Visual cues like bold text or an underline are currently used to denote the active page, but these visual treatments are hidden to visually impaired users.
📸 Before/After: Visually, the navigation links look identical to before, but they now contain proper semantic representations of their state in the DOM.
♿ Accessibility: This provides parity between the visual state and semantic state, allowing screen readers to inform users which navigation item corresponds to the current page they are viewing.

---
*PR created automatically by Jules for task [14558196342838693681](https://jules.google.com/task/14558196342838693681) started by @robertsmieja*