### PR TITLE
🎨 Palette: [UX improvement] Add `aria-current` to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-05-18 - Added aria-current to active navigation links
+**Learning:** Using purely visual indicators (like bold text or underlines) for active navigation links is insufficient for screen reader users. They need semantic context to understand which page is currently active.
+**Action:** Always use `aria-current="page"` on the active item in a navigation list, and conditionally set it to `undefined` when false so Astro cleanly omits the attribute.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +33,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +41,16 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +128,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +138,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
💡 **What:**
Replaced the `.active` CSS classes in the header navigation links with the semantic `aria-current="page"` attribute, and conditionally omitted the attribute for inactive links. The styling block was also updated to target `a[aria-current="page"]` instead of `a.active`.

🎯 **Why:**
Using purely visual indicators (like bold text or underlines) for active navigation links is insufficient for screen reader users. They need semantic context to understand which page is currently active.

📸 **Before/After:**
Visually, the navigation links remain identically styled (bold and underlined when active). However, semantically, the active link now contains `aria-current="page"`.

♿ **Accessibility:**
Screen readers will now properly announce the active page in the navigation menu, improving the accessibility and navigability of the website for visually impaired users.

---
*PR created automatically by Jules for task [171368668823149405](https://jules.google.com/task/171368668823149405) started by @robertsmieja*