### PR TITLE
🎨 Palette: [UX improvement] - Use semantic aria-current for active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+## 2026-06-10 - Use semantic aria-current for active navigation links
+**Learning:** Active navigation links that rely solely on visual CSS classes are not accessible to screen readers.
+**Action:** Always use the semantic aria-current="page" attribute on the active link and target this attribute in CSS instead of custom active classes.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +33,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +41,16 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +128,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +138,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
💡 **What**: Replaced the `.active` CSS class with the semantic `aria-current="page"` attribute for active navigation links in `Header.astro`. Updated CSS to target `a[aria-current="page"]`.
🎯 **Why**: Relying solely on visual CSS classes for active state is not accessible to screen readers. This change ensures assistive technologies can correctly announce which navigation link represents the currently active page.
📸 **Before/After**: Visually identical. Under the hood, `<a href="/" class="active">` is now `<a href="/" aria-current="page">`.
♿ **Accessibility**: Significant improvement for screen reader users navigating the site.

Also added a journal entry to `.jules/palette.md` to document this learning for future reference.

---
*PR created automatically by Jules for task [3724633462852366535](https://jules.google.com/task/3724633462852366535) started by @robertsmieja*