### PR TITLE
🎨 Palette: Improve active navigation link accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2026-06-12 - Semantic active navigation links
+**Learning:** Using only visual CSS classes (like `.active`) to indicate the current page leaves screen reader users without context about their current location in navigation menus.
+**Action:** Always use the semantic `aria-current="page"` attribute for active navigation links, and use `[aria-current="page"]` as the CSS selector to ensure visual styling is inherently tied to accessibility state.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +33,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +41,16 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +128,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +138,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
💡 **What:**
Replaced the `class="active"` attribute on the current page's navigation link in `src/components/Header.astro` with the semantic `aria-current="page"` attribute. Updated the associated CSS to target `a[aria-current="page"]` instead of `a.active`. Added a new journal entry documenting this learning.

🎯 **Why:**
Using only visual CSS classes leaves screen reader users without explicit context about their current location within a navigation menu. The `aria-current="page"` attribute semantically indicates the current item within a set of related elements.

📸 **Before/After:**
The visual styling remains completely identical (bold text with underline). See attached screenshots in the backend verification logs showing that the "Home" link receives `aria-current="page"` on the home page and styling applies correctly.

♿ **Accessibility:**
Screen readers will now announce "Current page" (or similar phrasing depending on the screen reader) when the user navigates to the active link in the main navigation header.

---
*PR created automatically by Jules for task [4745426660256030198](https://jules.google.com/task/4745426660256030198) started by @robertsmieja*