### PR TITLE
🎨 Palette: Semantic active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+## 2026-06-14 - Semantic active navigation links
+**Learning:** Using only visual CSS classes (like `.active`) for navigation links hides the active state from screen readers, creating an inconsistent experience.
+**Action:** Always use the semantic `aria-current="page"` attribute for active navigation links, and tie CSS styling directly to this attribute.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +33,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +41,16 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +128,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +138,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
💡 **What:** Replaced the purely visual `.active` CSS class with the semantic `aria-current="page"` attribute on active navigation links in `Header.astro`. The CSS selectors were also updated to target `a[aria-current="page"]` so the styling remains identical.
🎯 **Why:** Using only visual cues (like bold text and an underline via a CSS class) hides the active state from users navigating with screen readers. Providing the `aria-current="page"` attribute ensures that assistive technologies correctly announce which page is currently active.
📸 **Before/After:** The visual appearance is identical (bold text with an underline for the active link). The HTML structure changed from `<a href="/" class="active">Home</a>` to `<a href="/" aria-current="page">Home</a>`.
♿ **Accessibility:** Screen readers will now announce "Current page, Home, link" instead of just "Home, link", making the navigation interface much more intuitive for non-visual users.

---
*PR created automatically by Jules for task [488620172829451216](https://jules.google.com/task/488620172829451216) started by @robertsmieja*