### PR TITLE
🎨 Palette: Improve active navigation link accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-05-24 - Replaced visual-only active links with aria-current
+**Learning:** The site's navigation previously relied on a visual-only `.active` class to indicate the current page, which is a specific pattern in this app's components that fails to inform assistive technologies.
+**Action:** Always use the semantic `aria-current="page"` attribute for active navigation links and bind CSS styles to `a[aria-current="page"]` rather than custom classes.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +33,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +41,16 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +128,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +138,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
💡 **What**: Replaced the visual-only `.active` CSS class with the semantic `aria-current="page"` attribute for indicating the active page in the main navigation header. Updated the component's CSS to target `a[aria-current="page"]`.

🎯 **Why**: Previously, the active state of navigation links was only communicated visually. This change ensures that assistive technologies, like screen readers, are explicitly informed about which link corresponds to the currently viewed page, improving the overall accessibility of the site's main navigation.

📸 **Before/After**: Visually, the navigation links look identical. The "Home" link remains correctly bolded and underlined when on the root route.

♿ **Accessibility**: This is a direct enhancement for screen reader users, following ARIA best practices for navigation menus by definitively marking the active page link.

---
*PR created automatically by Jules for task [14105180168816723524](https://jules.google.com/task/14105180168816723524) started by @robertsmieja*