### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-05-24 - Semantic active state for navigation links
+**Learning:** The application's navigation components were relying exclusively on visual CSS classes to indicate the current page, leaving screen reader users without context about their current location.
+**Action:** Always use the semantic `aria-current="page"` attribute for active navigation links (setting false to `undefined` so Astro omits it) and target this attribute in CSS (`a[aria-current="page"]`) instead of using visual-only `.active` classes.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +33,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +41,16 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +128,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +138,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
### 💡 What
Replaced visual-only `.active` classes on navigation links with the semantic `aria-current="page"` attribute, and updated CSS selectors to target this attribute.

### 🎯 Why
Screen readers rely on semantics to convey context. While visually clear to sighted users, an `.active` class holds no semantic weight, meaning screen reader users wouldn't know which navigation item represented the current page they were on.

### 📸 Before/After
**Before:**
```astro
<a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
```
```css
a.active { font-weight: bold; }
```

**After:**
```astro
<a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a>
```
```css
a[aria-current="page"] { font-weight: bold; }
```

### ♿ Accessibility
Dramatically improves orientation for screen reader users by programmatically exposing the current active page in the navigation menu according to WAI-ARIA standards.

---
*PR created automatically by Jules for task [8081597468939169145](https://jules.google.com/task/8081597468939169145) started by @robertsmieja*