### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-05-24 - Added aria-current to active navigation links
+**Learning:** The navigation menu previously relied exclusively on visual CSS classes (`.active`) to indicate the active page, which is inaccessible to screen readers.
+**Action:** Always use the semantic `aria-current="page"` attribute on active links and target this attribute in CSS, conditionally setting it to `undefined` in Astro components when false.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +33,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +41,16 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +128,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +138,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
💡 **What**
Replaced the visually-only `.active` class with the semantic `aria-current="page"` attribute for active navigation links in `Header.astro`. Updated the CSS to target the `[aria-current="page"]` attribute selector. Added a new journal entry to `.jules/palette.md` detailing the learning.

🎯 **Why**
Relying exclusively on visual CSS classes (`.active`) to indicate the active page is inaccessible to users who rely on screen readers. By using the semantic `aria-current="page"` attribute, screen readers can accurately communicate the active page context to the user, significantly improving navigation accessibility.

📸 **Before/After**
Visually, the active state remains identical (bold text with an underline). Semantically, the HTML now correctly uses `aria-current="page"` instead of `class="active"`.

♿ **Accessibility**
This change provides crucial context to screen readers, allowing them to correctly announce which navigation link corresponds to the currently active page.

---
*PR created automatically by Jules for task [8656649979764849095](https://jules.google.com/task/8656649979764849095) started by @robertsmieja*