### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+## 2024-07-02 - Use aria-current="page" for active navigation links
+**Learning:** Using a visual CSS class (like `.active`) for active navigation links fails to communicate this state to screen readers, missing a crucial accessibility affordance.
+**Action:** Always use the semantic `aria-current="page"` attribute to denote the active navigation item, and update CSS selectors to target this attribute (e.g., `a[aria-current="page"]`) instead of relying on purely visual classes.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +33,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +41,16 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +128,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +138,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
💡 **What**: Replaced the purely visual `.active` CSS class with the semantic `aria-current="page"` attribute for active navigation links in `Header.astro`. The CSS selectors were updated to target `a[aria-current="page"]` instead of `a.active`.

🎯 **Why**: Using a visual CSS class (like `.active`) for active navigation links fails to communicate this state to screen readers. Using the semantic `aria-current="page"` attribute is a crucial accessibility affordance that provides this context.

📸 **Before/After**: The visual design remains identical (active links are bolded with an underline), but the underlying DOM now correctly uses `aria-current="page"` for the active item and cleanly omits the attribute for inactive items.

♿ **Accessibility**: This change significantly improves keyboard and screen reader navigation by explicitly denoting which page is currently active in the main navigation menu.

---
*PR created automatically by Jules for task [6219930620642340150](https://jules.google.com/task/6219930620642340150) started by @robertsmieja*