### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+## 2024-07-06 - Add aria-current to active navigation links
+**Learning:** Using purely visual CSS classes for active navigation links hides the link's state from screen readers.
+**Action:** Always use the semantic `aria-current="page"` attribute to denote active navigation links, styling them via the `a[aria-current="page"]` CSS selector.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +33,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +41,16 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +128,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +138,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
💡 **What:**
Replaced the purely visual `.active` CSS class with the semantic `aria-current="page"` attribute for active navigation links in the `Header.astro` component.

🎯 **Why:**
Using a visual class like `.active` to denote the current page provides no semantic information to screen reader users, leaving them unaware of their current context within the navigation menu.

📸 **Before/After:**
*Before:*
```html
<a href="/blog/" class="active">Blog</a>
```
*After:*
```html
<a href="/blog/" aria-current="page">Blog</a>
```
(Visual styling remains exactly the same, as the CSS selector was updated from `a.active` to `a[aria-current="page"]`).

♿ **Accessibility:**
By utilizing the standard ARIA attribute `aria-current="page"`, assistive technologies will now explicitly announce the currently active page when a user tabs through or reads the navigation menu, significantly improving the orientation and navigation experience for visually impaired users.

---
*PR created automatically by Jules for task [8536651084730507867](https://jules.google.com/task/8536651084730507867) started by @robertsmieja*