### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-10-25 - Use aria-current instead of visual active classes
+**Learning:** Relying purely on visual classes like `.active` for navigation state fails to communicate context to screen readers.
+**Action:** Always use the semantic `aria-current="page"` attribute (setting it to `undefined` when false in Astro) to indicate the active navigation link, and style against this attribute `[aria-current="page"]` rather than custom classes.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,12 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a>
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +32,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +40,13 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a href="/resume/" aria-current={pathname === "/resume/" ? "page" : undefined}>
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +124,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +134,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
- 💡 What: Replaced visual `.active` classes with semantic `aria-current="page"` attributes on active navigation links.
- 🎯 Why: To ensure screen readers announce the active page, improving accessibility for visually impaired users.
- 📸 Before/After: Before, an `.active` class was used. After, the `aria-current="page"` attribute is used and CSS is updated to target this attribute.
- ♿ Accessibility: Ensures WCAG compliance by communicating the active state semantically to assistive technologies.

---
*PR created automatically by Jules for task [4794656992266768743](https://jules.google.com/task/4794656992266768743) started by @robertsmieja*