### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-05-24 - Use aria-current for active navigation links
+**Learning:** Visual-only active states on navigation links hide critical current-page context from screen reader users.
+**Action:** Always use the semantic aria-current="page" attribute on active navigation links and bind CSS styles to that attribute instead of a dedicated class.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +33,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +41,16 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +128,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +138,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
💡 What: Replaced the visual-only `.active` class with the semantic `aria-current="page"` attribute for active navigation links in the `Header.astro` component.
🎯 Why: To improve the user experience by providing critical current-page context to screen reader users, while maintaining the same visual styling for sighted users.
📸 Before/After: Visual presentation remains exactly the same, but the underlying HTML now uses `aria-current="page"` instead of `class="active"`.
♿ Accessibility: Ensures that assistive technologies can correctly identify which navigation link corresponds to the currently active page.

---
*PR created automatically by Jules for task [17485240452901340791](https://jules.google.com/task/17485240452901340791) started by @robertsmieja*