### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-07-11 - Add aria-current to active navigation links
+**Learning:** Active state visual indicators like CSS classes are invisible to screen readers, removing navigation context.
+**Action:** Always use the semantic aria-current="page" attribute on the active link and target it in CSS.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +33,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +41,16 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +128,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +138,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
**💡 What:**
Replaced the visual `.active` class on active header navigation links with the semantic `aria-current="page"` attribute, and updated the CSS to style `a[aria-current="page"]` appropriately.

**🎯 Why:**
Using a pure CSS class (`.active`) for active navigation state provides only visual feedback. Screen readers and assistive technologies rely on semantic HTML attributes to convey state. By using `aria-current="page"`, we ensure all users have context about which page they are currently viewing within the site navigation.

**📸 Before/After:**
*   **Before:** `<a href="/blog/" class="active">Blog</a>`
*   **After:** `<a href="/blog/" aria-current="page">Blog</a>`
(Visual styling remains identical).

**♿ Accessibility:**
Improves WCAG compliance by providing programmatic state for the active navigation element, greatly enhancing context for screen reader users without altering the existing visual design. Added corresponding learning to Palette's journal.

---
*PR created automatically by Jules for task [10970140511725838508](https://jules.google.com/task/10970140511725838508) started by @robertsmieja*