### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-04-10 - Use aria-current for active navigation links
+**Learning:** Using purely visual CSS classes (like `.active`) for active navigation state deprives screen reader users of important context about their current location in the app.
+**Action:** Always use the semantic `aria-current="page"` attribute for active links and target this attribute in CSS, setting the false condition to `undefined` in Astro components.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +33,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +41,16 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +128,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +138,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
### 💡 What
Replaced the visual `.active` CSS class on navigation links with the semantic `aria-current="page"` attribute.

### 🎯 Why
Using purely visual CSS classes for active state deprives screen reader users of important context about their current location in the application. Using `aria-current="page"` solves this by providing semantic meaning to the active state.

### 📸 Before/After
Visually, there is no change. The CSS was updated to target `a[aria-current="page"]` instead of `a.active`.

### ♿ Accessibility
Significantly improves accessibility for screen reader users by properly announcing the currently active page in the main navigation.

---
*PR created automatically by Jules for task [15988918772168492068](https://jules.google.com/task/15988918772168492068) started by @robertsmieja*