### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-05-24 - Semantic active states for navigation
+**Learning:** Visual active classes (like `.active`) fail to convey active navigation state to screen readers. Relying exclusively on CSS classes for routing active states limits accessibility.
+**Action:** Always use the semantic `aria-current="page"` attribute on the active link and target this attribute in CSS for styling, ensuring both visual and screen reader accessibility.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +33,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +41,16 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +128,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +138,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
### 💡 What
Replaced the visual `.active` CSS class logic with semantic `aria-current="page"` attributes on active navigation links within the `Header.astro` component. The CSS styles have been updated to target `a[aria-current="page"]` instead of `a.active`.

### 🎯 Why
Visual styling classes (like `.active`) fail to programmatically convey the active navigation state to assistive technologies. Using a semantic attribute is a widely established web accessibility standard that improves the structural representation of the DOM.

### 📸 Before/After
Visually, the navigation links appear exactly as before. Functionally, when inspecting the DOM or using a screen reader, the active link now explicitly contains `aria-current="page"` instead of a generic `class="active"`.

### ♿ Accessibility
Screen readers (such as VoiceOver or NVDA) will now correctly announce "current page" when the user navigates over the active link in the main site header, improving spatial awareness and usability for visually impaired users.

---
*PR created automatically by Jules for task [10174373625504192095](https://jules.google.com/task/10174373625504192095) started by @robertsmieja*