### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-04-10 - Use aria-current for active navigation links
+**Learning:** Visual active states (like `.active` classes) don't provide context to screen reader users. The semantic `aria-current="page"` attribute conveys this state accessibly and can be used as a CSS selector.
+**Action:** Always use `aria-current="page"` on active navigation links and update associated CSS selectors to target `a[aria-current="page"]` instead of relying exclusively on visual CSS classes.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +33,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +41,16 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +128,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +138,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
### 💡 What
Replaced the `class:list={[{ active: condition }]}` on navigation links in `Header.astro` with the semantic `aria-current={condition ? "page" : undefined}` attribute. Updated the `Header.astro` styles to target `a[aria-current="page"]` instead of `a.active`.

### 🎯 Why
Visual styling via CSS classes (like `.active`) does not provide any context to users who rely on assistive technologies (like screen readers). Using the standard `aria-current="page"` attribute correctly informs these tools about the current active page while allowing us to achieve the exact same visual styling by using it as a CSS selector.

### 📸 Before/After
The visual state is perfectly identical, maintaining the bold text and underline for the active route.

### ♿ Accessibility
Huge win for screen reader users! They now receive explicit semantic feedback on their current location within the site navigation.

---
*PR created automatically by Jules for task [11727964367991338834](https://jules.google.com/task/11727964367991338834) started by @robertsmieja*