### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-05-24 - Semantic Active Navigation Links
+**Learning:** Relying exclusively on visual CSS classes (like `.active`) for navigation state hides the current page context from screen readers, significantly degrading accessibility.
+**Action:** Always use the semantic `aria-current="page"` attribute on the active link and update associated CSS selectors to target `a[aria-current="page"]` to ensure correct accessibility for screen readers.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +33,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +41,16 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +128,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +138,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
### 💡 What
Replaced the purely visual `.active` CSS class with the semantic `aria-current="page"` attribute for active navigation links in `src/components/Header.astro`. Updated corresponding CSS to target the `[aria-current="page"]` selector instead of `.active` to maintain existing visual styling. Recorded the associated critical learning in the Palette journal (`.jules/palette.md`).

### 🎯 Why
Relying exclusively on visual CSS classes (like `.active`) for navigation state hides the current page context from screen readers. By using the semantic `aria-current="page"` attribute, the active link state is properly exposed to assistive technologies, making the navigation experience more inclusive.

### 📸 Before/After
No visual changes were made. The CSS was successfully updated to ensure the navigation links remain visually identical (bold and underlined) for sighted users, while the underlying HTML structure is now fully accessible.

### ♿ Accessibility
Significantly improves accessibility for screen reader users by programmatically identifying the currently active page in the navigation menu, eliminating the reliance on visual-only indicators.

---
*PR created automatically by Jules for task [4511166746919130172](https://jules.google.com/task/4511166746919130172) started by @robertsmieja*