### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+
+## 2024-05-15 - Use aria-current for active navigation links
+**Learning:** Relying solely on visual CSS classes (like `.active`) for navigation state leaves screen reader users without context about their current page location.
+**Action:** Always use the semantic `aria-current="page"` attribute to denote the active route in navigation menus, and style based on that attribute (`[aria-current="page"]`).

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +33,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +41,16 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +128,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +138,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
💡 **What**: Replaced the purely visual `.active` CSS class with the semantic `aria-current="page"` attribute for denoting the active link in the navigation menu (`Header.astro`). Updated the corresponding CSS styles to target `a[aria-current="page"]` instead of `a.active`. Added a new critical learning entry to `.jules/palette.md` detailing this accessibility improvement.

🎯 **Why**: Using only visual cues (like a bold font or underline via the `.active` class) leaves visually impaired users and screen reader users without context as to which page they are currently on. `aria-current="page"` provides proper semantic meaning to assistive technologies, making the navigation menu fully accessible.

📸 **Before/After**: The visual appearance of the active link (bold font and underline) remains completely identical, but the underlying HTML now includes the semantic `aria-current="page"` attribute.

♿ **Accessibility**: This change directly addresses a common WCAG accessibility issue by communicating the active route state to screen readers.

---
*PR created automatically by Jules for task [16041782701009808658](https://jules.google.com/task/16041782701009808658) started by @robertsmieja*