### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+## 2024-04-10 - Accessible active navigation links
+**Learning:** Visual-only indicators for active navigation links (e.g., `.active` CSS classes) are not announced by screen readers, making it harder for visually impaired users to understand their current location in the app.
+**Action:** Always use the semantic `aria-current="page"` attribute to denote active navigation links and bind CSS styling directly to `[aria-current="page"]` to ensure accessibility and styling are intrinsically linked.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +33,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +41,16 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +128,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +138,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
### 💡 What
Replaced the `.active` CSS class with the semantic `aria-current="page"` attribute to denote active navigation links in the `Header.astro` component. Updated the corresponding CSS styles to target `a[aria-current="page"]`.

### 🎯 Why
Using only visual indicators (like bolding text via a CSS class) for the active page means that visually impaired users utilizing screen readers are not informed of their current context within the navigation menu.

### 📸 Before/After
**Before:**
```astro
<a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
```

**After:**
```astro
<a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a>
```

### ♿ Accessibility
Screen readers will now correctly announce the active page when users traverse the navigation menu, improving contextual awareness without altering the existing visual design.

---
*PR created automatically by Jules for task [12530790944048662299](https://jules.google.com/task/12530790944048662299) started by @robertsmieja*