### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+## 2025-01-20 - Add aria-current to active navigation links
+**Learning:** Using purely visual CSS classes (like `.active`) for active navigation links hides this state from screen readers. Active navigation states should be communicated semantically.
+**Action:** Always use the `aria-current="page"` attribute for active links and target `a[aria-current="page"]` in CSS instead of relying exclusively on visual classes.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,13 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a href="/" aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
-          class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -32,7 +33,7 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/presentations/"
-          class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -40,13 +41,16 @@ const pathname = Astro.url.pathname
       <li>
         <a
           href="/projects/"
-          class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +128,7 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +138,7 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
💡 What: Replaced visual `.active` classes with semantic `aria-current="page"` for active navigation links.
🎯 Why: Ensures screen readers can correctly announce the active page in the navigation menu, while maintaining the existing visual styles.
📸 Before/After: Visual presentation (bold and underline) remains unchanged, but the underlying HTML is now accessible.
♿ Accessibility: Improves navigation clarity for assistive technologies.

---
*PR created automatically by Jules for task [7092693584128839123](https://jules.google.com/task/7092693584128839123) started by @robertsmieja*