### PR TITLE
🎨 Palette: Add aria-current to active navigation links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-04-09 - Added actionable link to empty 404 state
 **Learning:** Empty states in routing (like 404 pages) should always provide a clear path forward to prevent user frustration. Users who encounter a dead end without a recovery path are more likely to bounce.
 **Action:** Always include a "Return to Homepage" or similar functional link on error/not found pages to maintain user flow.
+## 2024-04-10 - Add aria-current to active navigation links
+**Learning:** Visual-only indicators for active navigation links (like an `.active` CSS class) are insufficient for screen readers, which rely on semantic attributes to announce the current page.
+**Action:** Always use `aria-current="page"` on active navigation links in addition to or instead of visual-only classes, and style using the attribute selector `[aria-current="page"]`.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,12 +19,17 @@ const pathname = Astro.url.pathname
         </a>
       </li>
       <li>
-        <a href="/" class:list={[{ active: pathname === "/" }]}>Home</a>
+        <a
+          href="/"
+          class:list={[{ active: pathname === "/" }]}
+          aria-current={pathname === "/" ? "page" : undefined}>Home</a
+        >
       </li>
       <li>
         <a
           href="/blog/"
           class:list={[{ active: pathname.startsWith("/blog/") }]}
+          aria-current={pathname.startsWith("/blog/") ? "page" : undefined}
         >
           Blog
         </a>
@@ -33,6 +38,7 @@ const pathname = Astro.url.pathname
         <a
           href="/presentations/"
           class:list={[{ active: pathname === "/presentations/" }]}
+          aria-current={pathname === "/presentations/" ? "page" : undefined}
         >
           Presentations
         </a>
@@ -41,12 +47,17 @@ const pathname = Astro.url.pathname
         <a
           href="/projects/"
           class:list={[{ active: pathname === "/projects/" }]}
+          aria-current={pathname === "/projects/" ? "page" : undefined}
         >
           Projects
         </a>
       </li>
       <li>
-        <a href="/resume/" class:list={[{ active: pathname === "/resume/" }]}>
+        <a
+          href="/resume/"
+          class:list={[{ active: pathname === "/resume/" }]}
+          aria-current={pathname === "/resume/" ? "page" : undefined}
+        >
           R&eacute;sum&eacute;
         </a>
       </li>
@@ -124,7 +135,8 @@ const pathname = Astro.url.pathname
 
   a:hover,
   a:focus-visible,
-  a.active {
+  a.active,
+  a[aria-current="page"] {
     text-decoration: underline;
     text-underline-offset: 4px;
   }
@@ -134,7 +146,8 @@ const pathname = Astro.url.pathname
     outline-offset: 2px;
   }
 
-  a.active {
+  a.active,
+  a[aria-current="page"] {
     font-weight: bold;
   }
 </style>


### PR DESCRIPTION
💡 What: Added `aria-current="page"` to the active navigation links in the header, alongside the existing `.active` class.
🎯 Why: Screen readers rely on semantic attributes like `aria-current` to announce the current page in a navigation menu, making the site more accessible than relying on visual-only CSS classes.
📸 Before/After: Visuals remain unchanged (verified via screenshot). 
♿ Accessibility: Screen readers will now announce "Current Page" when focused on the active navigation link.

---
*PR created automatically by Jules for task [13396035149215051060](https://jules.google.com/task/13396035149215051060) started by @robertsmieja*