### PR TITLE
⚡ Bolt: Extract Intl.DateTimeFormat in blog index

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -4,6 +4,14 @@ import Layout from "../../layouts/Layout.astro"
 import { sortBlogPosts } from "../../lib/blogUtils"
 
 const posts = sortBlogPosts(await getCollection("blog"))
+
+// ⚡ Bolt: Extract Intl.DateTimeFormat instantiation out of the render loop to prevent
+// redundant memory allocations and initialization overhead during mapping.
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+})
 ---
 
 <Layout
@@ -24,14 +32,7 @@ const posts = sortBlogPosts(await getCollection("blog"))
         <ul class="post-list">
           {posts.map((post) => {
             const title = post.data.title || post.slug
-            const formattedDate = new Date(post.data.date).toLocaleDateString(
-              "en-US",
-              {
-                year: "numeric",
-                month: "long",
-                day: "numeric",
-              }
-            )
+            const formattedDate = dateFormatter.format(new Date(post.data.date))
             return (
               <li class="post-item">
                 <h3 class="post-title">


### PR DESCRIPTION
💡 **What:** 
Extracted the `Intl.DateTimeFormat` object instantiation (previously hidden inside `.toLocaleDateString(...)`) outside of the `posts.map` render loop in `src/pages/blog/index.astro`.

🎯 **Why:** 
Creating `Intl` objects in JavaScript (like `Intl.DateTimeFormat`) is a known expensive operation due to internal ICU library initialization. When mapping over a list of blog posts, instantiating a new formatter for every single post creates redundant CPU overhead and memory allocation. Reusing a single instance is significantly faster.

📊 **Impact:** 
Reduces redundant object allocations during the SSG build process. While the impact per item is measured in milliseconds, reusing the formatter turns an $O(N)$ initialization cost into an $O(1)$ cost, which scales much better as the number of blog posts grows.

🔬 **Measurement:** 
Run `pnpm build` and verify that the SSG build completes without errors and the generated static HTML files still display the formatted dates correctly. Visual verification via screenshot confirms the formatting is unchanged.

---
*PR created automatically by Jules for task [6280861710567239623](https://jules.google.com/task/6280861710567239623) started by @robertsmieja*