### PR TITLE
⚡ Bolt: Extract Intl.DateTimeFormat for faster SSG builds

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -19,12 +19,14 @@ export async function getStaticPaths() {
 const { post, previous, next } = Astro.props
 const { Content } = await post.render()
 
-const formatDate = (d: string) =>
-  new Date(d).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  })
+// ⚡ Bolt: Extract Intl.DateTimeFormat for consistency and performance
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+})
+
+const formatDate = (d: string) => dateFormatter.format(new Date(d))
 
 const formattedDate = formatDate(post.data.date)
 const formattedUpdated =

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -4,6 +4,15 @@ import Layout from "../../layouts/Layout.astro"
 import { sortBlogPosts } from "../../lib/blogUtils"
 
 const posts = sortBlogPosts(await getCollection("blog"))
+
+// ⚡ Bolt: Extract Intl.DateTimeFormat out of the component loop
+// This prevents creating a new formatter instance for every single blog post
+// during static site generation, improving build performance.
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+})
 ---
 
 <Layout
@@ -24,14 +33,7 @@ const posts = sortBlogPosts(await getCollection("blog"))
         <ul class="post-list">
           {posts.map((post) => {
             const title = post.data.title || post.slug
-            const formattedDate = new Date(post.data.date).toLocaleDateString(
-              "en-US",
-              {
-                year: "numeric",
-                month: "long",
-                day: "numeric",
-              }
-            )
+            const formattedDate = dateFormatter.format(new Date(post.data.date))
             return (
               <li class="post-item">
                 <h3 class="post-title">


### PR DESCRIPTION
💡 What: Extracted the `Intl.DateTimeFormat` instantiation out of the `map` loop in `src/pages/blog/index.astro` and outside the helper function in `src/pages/blog/[...slug].astro`.
🎯 Why: Instantiating `Intl.DateTimeFormat` is an expensive operation in JavaScript. Creating it repeatedly during static site generation causes unnecessary CPU overhead, especially as the number of blog posts grows.
📊 Impact: Improves build performance during Static Site Generation (SSG). Less CPU usage and faster build times.
🔬 Measurement: Verified correct formatting output using a Playwright script targeting the static HTML output.

---
*PR created automatically by Jules for task [107789166939881605](https://jules.google.com/task/107789166939881605) started by @robertsmieja*